### PR TITLE
[PC-62] Feat: feature 모듈을 생성하는 tuist 템플릿 구현

### DIFF
--- a/Tuist/ProjectDescriptionHelpers/TemplateAttributeValue+default.swift
+++ b/Tuist/ProjectDescriptionHelpers/TemplateAttributeValue+default.swift
@@ -1,0 +1,29 @@
+//
+//  TemplateAttributeValue+default.swift
+//  AppManifests
+//
+//  Created by summercat on 1/2/25.
+//
+
+import Foundation
+import ProjectDescription
+
+public extension Template.Attribute.Value {
+    static var defaultYear: Template.Attribute.Value {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy"
+        
+        return .string(dateFormatter.string(from: Date()))
+    }
+    
+    static var defaultDate: Template.Attribute.Value {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy/MM/dd"
+        
+        return .string(dateFormatter.string(from: Date()))
+    }
+    
+    static var defaultAuthor: Template.Attribute.Value {
+        return .string(ProcessInfo.processInfo.fullUserName)
+    }
+}

--- a/Tuist/Templates/feature/Project.stencil
+++ b/Tuist/Templates/feature/Project.stencil
@@ -1,0 +1,16 @@
+//
+// Project.swift
+// {{ name }}
+//
+// Created by {{ author }} on {{ date }}.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.staticLibrary(
+  name: Modules.Presentation.{{ name }}.rawValue,
+  dependencies: [
+    .presentation(target: .DesignSystem),
+  ]
+)

--- a/Tuist/Templates/feature/View.stencil
+++ b/Tuist/Templates/feature/View.stencil
@@ -1,0 +1,15 @@
+//
+// {{ name }}View.swift
+// {{ name }}
+//
+// Created by {{ author }} on {{ date }}.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct {{ name }}View: View {
+  var body: some View {
+  
+  }
+}

--- a/Tuist/Templates/feature/View.stencil
+++ b/Tuist/Templates/feature/View.stencil
@@ -9,6 +9,8 @@ import SwiftUI
 import DesignSystem
 
 struct {{ name }}View: View {
+  @State var viewModel: {{ name }}ViewModel
+
   var body: some View {
   
   }

--- a/Tuist/Templates/feature/ViewModel.stencil
+++ b/Tuist/Templates/feature/ViewModel.stencil
@@ -7,6 +7,7 @@
 
 import Foundation
 
-final class {{ name }}ViewModel: ObservableObject {
-
+@Observable
+final class {{ name }}ViewModel {
+  enum Action { }
 }

--- a/Tuist/Templates/feature/ViewModel.stencil
+++ b/Tuist/Templates/feature/ViewModel.stencil
@@ -1,0 +1,12 @@
+//
+// {{ name }}ViewModel.swift
+// {{ name }}
+//
+// Created by {{ author }} on {{ date }}.
+//
+
+import Foundation
+
+final class {{ name }}ViewModel: ObservableObject {
+
+}

--- a/Tuist/Templates/feature/feature.swift
+++ b/Tuist/Templates/feature/feature.swift
@@ -1,0 +1,35 @@
+//
+//  feature.swift
+//  AppManifests
+//
+//  Created by summercat on 1/2/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+private let nameAttribute: Template.Attribute = .required("name")
+private let yearAttribute: Template.Attribute = .optional("year", default: .defaultYear)
+private let dateAttribute: Template.Attribute = .optional("date", default: .defaultDate)
+private let authorAttribute: Template.Attribute = .optional("author", default: .defaultAuthor)
+
+let featureTemplate = Template(
+    description: "presentation 레이어의 feature 모듈 생성",
+    attributes: [
+        nameAttribute,
+        yearAttribute,
+        dateAttribute,
+        authorAttribute,
+    ],
+    items: [
+        .file(
+            path: "Presentation/Feature/\(nameAttribute)/Project.swift",
+            templatePath: "Project.stencil"),
+        .file(
+            path: "Presentation/Feature/\(nameAttribute)/Sources/\(nameAttribute)View.swift",
+            templatePath: "View.stencil"),
+        .file(
+            path: "Presentation/Feature/\(nameAttribute)/Sources/\(nameAttribute)ViewModel.swift",
+            templatePath: "ViewModel.stencil"),
+    ]
+)


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-62](https://yapp25app3.atlassian.net/browse/PC-62)

## 👷🏼‍♂️ 변경 사항
- `feature` 모듈 생성에 필요한 `Project.swift`, `View`, `ViewModel` 파일을 생성해주는 템플릿 구현
 
## 💬 참고 사항
- 사용방법
  1. 터미널에 `tuist scaffold feature --name {{ 피처이름 }}` 입력 시 해당 파일 생성
    - 피처 이름은 Pascal case로 입력 (예: 매칭 메인 피처의 경우 `MatchingMain`)
  2. `tuist edit` - `Tuist/Modules.swift` 파일에 해당 피처 추가

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-62]: https://yapp25app3.atlassian.net/browse/PC-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ