### PR TITLE
[PC-196] 매칭 상세 가치관 Pick UI 구현

### DIFF
--- a/Presentation/DesignSystem/Resources/Icons.xcassets/photo-line-32.imageset/Contents.json
+++ b/Presentation/DesignSystem/Resources/Icons.xcassets/photo-line-32.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "photo-line-32.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Presentation/DesignSystem/Resources/Icons.xcassets/photo-line-32.imageset/photo-line-32.svg
+++ b/Presentation/DesignSystem/Resources/Icons.xcassets/photo-line-32.imageset/photo-line-32.svg
@@ -1,0 +1,6 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 16.5V16.5C11.4859 17.7908 16.3311 20.997 19.6639 25.5416L20 26" stroke="#1B1A2A" stroke-width="1.6"/>
+<path d="M26 16L25.103 16.1414C21.3319 16.7358 17.8187 18.4253 15 21V21" stroke="#1B1A2A" stroke-width="1.6"/>
+<rect x="6" y="6" width="20" height="20" rx="1" stroke="#1B1A2A" stroke-width="1.6" stroke-linejoin="round"/>
+<path d="M21 13C22.1046 13 23 12.1046 23 11C23 9.89544 22.1046 9 21 9C19.8954 9 19 9.89544 19 11C19 12.1046 19.8954 13 21 13Z" stroke="#1B1A2A" stroke-width="1.6"/>
+</svg>

--- a/Presentation/DesignSystem/Sources/PCTabMini.swift
+++ b/Presentation/DesignSystem/Sources/PCTabMini.swift
@@ -1,0 +1,43 @@
+//
+//  PCTabMini.swift
+//  DesignSystem
+//
+//  Created by summercat on 1/14/25.
+//
+
+import SwiftUI
+
+public struct PCMiniTab<Content: View>: View {
+  public init(
+    isSelected: Bool,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.isSelected = isSelected
+    self.content = content()
+  }
+  
+  public var body: some View {
+    content
+      .pretendard(.body_M_M)
+      .foregroundStyle(isSelected ? Color.grayscaleBlack : Color.grayscaleDark3)
+      .frame(maxWidth: .infinity)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 12)
+      .contentShape(Rectangle())
+  }
+  
+  @State var isSelected: Bool
+  @ViewBuilder let content: Content
+}
+
+#Preview {
+  HStack(alignment: .top) {
+    PCMiniTab(isSelected: true) {
+      Text("전체")
+    }
+    
+    PCMiniTab(isSelected: false) {
+      Text("전체")
+    }
+  }
+}

--- a/Presentation/DesignSystem/Sources/PCTextButton.swift
+++ b/Presentation/DesignSystem/Sources/PCTextButton.swift
@@ -1,0 +1,32 @@
+//
+//  PCTextButton.swift
+//  DesignSystem
+//
+//  Created by summercat on 1/14/25.
+//
+
+import SwiftUI
+
+public struct PCTextButton: View {
+  public init(content: String) {
+    self.content = content
+  }
+  
+  public var body: some View {
+      Text(content)
+        .pretendard(.body_M_M)
+        .foregroundStyle(Color.grayscaleDark3)
+        .overlay(alignment: .bottom) {
+          Rectangle()
+            .foregroundStyle(Color.grayscaleDark3)
+            .frame(height: 1)
+        }
+        .contentShape(Rectangle())
+  }
+  
+  let content: String
+}
+
+#Preview {
+  PCTextButton(content: "텍스트")
+}

--- a/Presentation/DesignSystem/Sources/RoundedButton.swift
+++ b/Presentation/DesignSystem/Sources/RoundedButton.swift
@@ -46,13 +46,15 @@ public struct RoundedButton: View {
     type: ButtonType,
     buttonText: String,
     icon: Image?,
-    height: CGFloat? = 36,
+    height: CGFloat? = 52,
+    rounding: Bool = false,
     action: @escaping () -> Void
   ) {
     self.type = type
     self.buttonText = buttonText
     self.icon = icon
     self.height = height
+    self.rounding = rounding
     self.action = action
   }
   
@@ -71,23 +73,44 @@ public struct RoundedButton: View {
           .foregroundStyle(type.contentColor)
       }
       .frame(height: height)
-      .frame(maxWidth: .infinity)
+      .padding(.horizontal, rounding ? 28 : 12)
       .background(
-        RoundedRectangle(cornerRadius: 8)
-          .foregroundStyle(type.backgroundColor)
+        backgroundView
       )
       .overlay(
-        RoundedRectangle(cornerRadius: 8)
-          .strokeBorder(type.borderColor, lineWidth: 1)
+        border
       )
     }
     .disabled(type == .disabled)
+  }
+  
+  @ViewBuilder
+  private var backgroundView: some View {
+    if rounding {
+      Capsule()
+        .foregroundStyle(type.backgroundColor)
+    } else {
+      RoundedRectangle(cornerRadius: 8)
+        .foregroundStyle(type.backgroundColor)
+    }
+  }
+  
+  @ViewBuilder
+  private var border: some View {
+    if rounding {
+      Capsule()
+        .strokeBorder(type.borderColor, lineWidth: 1)
+    } else {
+      RoundedRectangle(cornerRadius: 8)
+        .strokeBorder(type.borderColor, lineWidth: 1)
+    }
   }
   
   private let type: ButtonType
   private let buttonText: String
   private let icon: Image?
   private let height: CGFloat?
+  private let rounding: Bool
   private let action: () -> Void
 }
 
@@ -97,6 +120,7 @@ public struct RoundedButton: View {
       type: .solid,
       buttonText: "Solid",
       icon: nil,
+      rounding: true,
       action: {
       })
     RoundedButton(
@@ -109,6 +133,13 @@ public struct RoundedButton: View {
       type: .outline,
       buttonText: "Outline w/ icon",
       icon: DesignSystemAsset.Icons.question20.swiftUIImage,
+      action: {
+      })
+    RoundedButton(
+      type: .outline,
+      buttonText: "Outline w/ icon",
+      icon: DesignSystemAsset.Icons.question20.swiftUIImage,
+      rounding: true,
       action: {
       })
     RoundedButton(

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickAnswerModel.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickAnswerModel.swift
@@ -1,0 +1,12 @@
+//
+//  ValuePickAnswerModel.swift
+//  MatchingDetail
+//
+//  Created by summercat on 1/13/25.
+//
+
+struct ValuePickAnswerModel: Identifiable {
+  let id: Int
+  let content: String
+  let isSelected: Bool
+}

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickCard.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickCard.swift
@@ -1,0 +1,91 @@
+//
+//  ValuePickCard.swift
+//  MatchingDetail
+//
+//  Created by summercat on 1/13/25.
+//
+
+import DesignSystem
+import SwiftUI
+
+struct ValuePickCard: View {
+  init(valuePick: ValuePickModel) {
+    self.valuePick = valuePick
+  }
+  
+  private let valuePick: ValuePickModel
+  
+  var body: some View {
+    VStack(spacing: 24) {
+      question
+      answers
+    }
+    .padding(.horizontal, 20)
+    .padding(.vertical, 24)
+    .background {
+      RoundedRectangle(cornerRadius: 12)
+        .foregroundStyle(Color.grayscaleWhite)
+    }
+  }
+  
+  private var question: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .center) {
+        category
+        Spacer()
+        if valuePick.isSame {
+          Badge(badgeText: "나와 같은")
+        }
+      }
+      
+      Text(valuePick.question)
+        .lineLimit(2)
+        .multilineTextAlignment(.leading)
+        .pretendard(.body_M_SB)
+        .foregroundStyle(Color.grayscaleBlack)
+    }
+  }
+  
+  private var category: some View {
+    HStack(alignment: .center, spacing: 6) {
+      DesignSystemAsset.Icons.question20.swiftUIImage
+        .renderingMode(.template)
+        .foregroundStyle(Color.primaryDefault)
+      
+      Text(valuePick.category)
+        .pretendard(.body_S_SB)
+        .foregroundStyle(Color.primaryDefault)
+    }
+  }
+  
+  private var answers: some View {
+    VStack(spacing: 8) {
+      ForEach(valuePick.answers) { answer in
+        SelectCard(isSelected: answer.isSelected, text: answer.content)
+      }
+    }
+  }
+}
+
+#Preview {
+  ValuePickCard(
+    valuePick: ValuePickModel(
+      id: 0,
+      category: "음주",
+      question: "연인과 함께 술을 마시는 것을 좋아하나요?",
+      answers: [
+        ValuePickAnswerModel(
+          id: 1,
+          content: "함께 술을 즐기고 싶어요",
+          isSelected: true
+        ),
+        ValuePickAnswerModel(
+          id: 2,
+          content: "같이 술을 즐길 수 없어도 괜찮아요",
+          isSelected: false
+        ),
+      ],
+      isSame: true
+    )
+  )
+}

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickModel.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickModel.swift
@@ -1,0 +1,14 @@
+//
+//  ValuePickModel.swift
+//  MatchingDetail
+//
+//  Created by summercat on 1/13/25.
+//
+
+struct ValuePickModel: Identifiable {
+  let id: Int
+  let category: String
+  let question: String
+  let answers: [ValuePickAnswerModel]
+  let isSame: Bool
+}

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickTab.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickTab.swift
@@ -1,0 +1,24 @@
+//
+//  ValuePickTab.swift
+//  MatchingDetail
+//
+//  Created by summercat on 1/14/25.
+//
+
+enum ValuePickTab: CaseIterable, Identifiable {
+  case all
+  case same
+  case different
+  
+  var id: String {
+    return self.description
+  }
+  
+  var description: String {
+    switch self {
+    case .all: "전체"
+    case .same: "나와 같은"
+    case .different: "나와 다른"
+    }
+  }
+}

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
@@ -11,6 +11,8 @@ import SwiftUI
 struct ValuePickView: View {
   private enum Constant {
     static let horizontalPadding: CGFloat = 20
+    static let accepetButtonText = "매칭 수락하기"
+    static let denyButtonText = "매칭 거절하기"
   }
   
   @State var viewModel: ValuePickViewModel
@@ -52,7 +54,7 @@ struct ValuePickView: View {
         })) {
           pickCards
           
-          PCTextButton(content: "매칭 거절하기")
+          PCTextButton(content: Constant.denyButtonText)
             .onTapGesture {
               viewModel.handleAction(.didTapDenyButton)
             }
@@ -147,7 +149,7 @@ struct ValuePickView: View {
       
       RoundedButton(
         type: .solid,
-        buttonText: "매칭 수락하기",
+        buttonText: Constant.accepetButtonText,
         icon: nil,
         rounding: true,
         action: { viewModel.handleAction(.didTapAcceptButton) }

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
@@ -51,6 +51,14 @@ struct ValuePickView: View {
           viewModel.handleAction(.contentOffsetDidChange(offset))
         })) {
           pickCards
+          
+          PCTextButton(content: "매칭 거절하기")
+            .onTapGesture {
+              viewModel.handleAction(.didTapDenyButton)
+            }
+          
+          Spacer()
+            .frame(height: 60)
         }
         .scrollIndicators(.never)
         .background(Color.grayscaleLight3)
@@ -116,6 +124,8 @@ struct ValuePickView: View {
     .padding(.top, 20)
     .padding(.bottom, 60)
   }
+  
+  // MARK: - 하단 버튼
   
   private var bottomButtons: some View {
     HStack(alignment: .center, spacing: 8) {

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
@@ -1,0 +1,217 @@
+//
+//  ValuePickView.swift
+//  MatchingDetail
+//
+//  Created by summercat on 1/13/25.
+//
+
+import DesignSystem
+import SwiftUI
+
+struct ValuePickView: View {
+  private enum Constant {
+    static let horizontalPadding: CGFloat = 20
+  }
+  
+  @State var viewModel: ValuePickViewModel
+  @State private var contentOffset: CGFloat = 0
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      NavigationBar(
+        title: viewModel.navigationTitle,
+        titleColor: .grayscaleBlack,
+        rightButtonTap: {
+          viewModel.handleAction(.didTapCloseButton)
+        },
+        backgroundColor: .grayscaleWhite
+      )
+      .overlay(alignment: .bottom) {
+        Divider(weight: .normal, isVertical: false)
+      }
+      
+      if viewModel.isNameViewVisible {
+        BasicInfoNameView(
+          description: viewModel.description,
+          nickname: viewModel.nickname
+        ) {
+          viewModel.handleAction(.didTapMoreButton)
+        }
+        .padding(20)
+        .background(Color.grayscaleWhite)
+        .transition(.move(edge: .top).combined(with: .opacity))
+      }
+      
+      tabs
+      
+      ObservableScrollView(
+        contentOffset: Binding(get: {
+          viewModel.contentOffset
+        }, set: { offset in
+          viewModel.handleAction(.contentOffsetDidChange(offset))
+        })) {
+          pickCards
+        }
+        .scrollIndicators(.never)
+        .background(Color.grayscaleLight3)
+      
+      bottomButtons
+    }
+  }
+  
+  // MARK: - 탭
+  
+  private var tabs: some View {
+    ZStack(alignment: .bottom) {
+      HStack(spacing: 0) {
+        ForEach(viewModel.tabs) { tab in
+          PCMiniTab(isSelected: viewModel.selectedTab == tab) {
+            switch tab {
+            case .all:
+              Text(tab.description)
+            case .same:
+              HStack(spacing: 6) {
+                Text(tab.description)
+                Text(7.description) // TODO: - API 확인 후 수정
+              }
+            case .different:
+              HStack(spacing: 6) {
+                Text(tab.description)
+                Text(3.description) // TODO: - API 확인 후 수정
+              }
+            }
+          }
+          .onTapGesture {
+            withAnimation {
+              viewModel.handleAction(.didSelectTab(tab))
+            }
+          }
+        }
+      }
+      
+      GeometryReader { geometry in
+        let tabWidth = geometry.size.width / CGFloat(viewModel.tabs.count)
+        let offset = tabWidth * CGFloat(viewModel.tabs.firstIndex(of: viewModel.selectedTab) ?? 0)
+        Rectangle()
+          .frame(width: tabWidth, height: 2)
+          .foregroundStyle(Color.grayscaleBlack)
+          .offset(x: offset)
+          .animation(.spring, value: viewModel.selectedTab)
+      }
+      .frame(height: 2)
+    }
+    .frame(height: 48)
+    .background(Color.grayscaleWhite)
+  }
+  
+  // MARK: - Pick Card
+  
+  private var pickCards: some View {
+    VStack(spacing: 20) {
+      ForEach(viewModel.displayedValuePicks) { valuePick in
+        ValuePickCard(valuePick: valuePick)
+      }
+    }
+    .padding(.horizontal, Constant.horizontalPadding)
+    .padding(.top, 20)
+    .padding(.bottom, 60)
+  }
+  
+  private var bottomButtons: some View {
+    HStack(alignment: .center, spacing: 8) {
+      CircleButton(
+        type: .outline,
+        icon: DesignSystemAsset.Icons.photoLine32.swiftUIImage
+      ) {
+        viewModel.handleAction(.didTapPhotoButton)
+      }
+      
+      Spacer()
+      
+      CircleButton(
+        type: .solid,
+        icon: DesignSystemAsset.Icons.arrowLeft32.swiftUIImage
+      ) {
+        viewModel.handleAction(.didTapPreviousButton)
+      }
+      
+      RoundedButton(
+        type: .solid,
+        buttonText: "매칭 수락하기",
+        icon: nil,
+        rounding: true,
+        action: { viewModel.handleAction(.didTapAcceptButton) }
+      )
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.horizontal, 20)
+    .padding(.top, 12)
+    .padding(.bottom, 10)
+    .background(Color.grayscaleLight3)
+  }
+}
+
+#Preview {
+  ValuePickView(
+    viewModel: ValuePickViewModel(
+      description: "음악과 요리를 좋아하는",
+      nickname: "수줍은 수달",
+      valuePicks: [
+        ValuePickModel(
+          id: 0,
+          category: "음주",
+          question: "연인과 함께 술을 마시는 것을 좋아하나요?",
+          answers: [
+            ValuePickAnswerModel(
+              id: 1,
+              content: "함께 술을 즐기고 싶어요",
+              isSelected: false
+            ),
+            ValuePickAnswerModel(
+              id: 2,
+              content: "같이 술을 즐길 수 없어도 괜찮아요",
+              isSelected: true
+            ),
+          ],
+          isSame: true
+        ),
+        ValuePickModel(
+          id: 1,
+          category: "음주",
+          question: "연인과 함께 술을 마시는 것을 좋아하나요?",
+          answers: [
+            ValuePickAnswerModel(
+              id: 1,
+              content: "함께 술을 즐기고 싶어요",
+              isSelected: true
+            ),
+            ValuePickAnswerModel(
+              id: 2,
+              content: "같이 술을 즐길 수 없어도 괜찮아요",
+              isSelected: false
+            ),
+          ],
+          isSame: true
+        ),
+        ValuePickModel(
+          id: 2,
+          category: "음주",
+          question: "연인과 함께 술을 마시는 것을 좋아하나요?",
+          answers: [
+            ValuePickAnswerModel(
+              id: 1,
+              content: "함께 술을 즐기고 싶어요",
+              isSelected: true
+            ),
+            ValuePickAnswerModel(
+              id: 2,
+              content: "같이 술을 즐길 수 없어도 괜찮아요",
+              isSelected: false
+            ),
+          ],
+          isSame: false
+        )
+      ]
+    )
+  )
+}

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickViewModel.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickViewModel.swift
@@ -1,0 +1,96 @@
+//
+//  ValuePickViewModel.swift
+//  MatchingDetail
+//
+//  Created by summercat on 1/13/25.
+//
+
+import Foundation
+
+enum ValuePickTab: CaseIterable, Identifiable {
+  case all
+  case same
+  case different
+  
+  var id: String {
+    return self.description
+  }
+  
+  var description: String {
+    switch self {
+    case .all: "전체"
+    case .same: "나와 같은"
+    case .different: "나와 다른"
+    }
+  }
+}
+
+@Observable
+final class ValuePickViewModel {
+  private enum Constant {
+    static let navigationTitle = "가치관 Pick"
+    static let nameVisibilityOffset: CGFloat = -100
+  }
+  
+  enum Action {
+    case contentOffsetDidChange(CGFloat)
+    case didTapCloseButton
+    case didTapMoreButton
+    case didSelectTab(ValuePickTab)
+    case didTapPhotoButton
+    case didTapPreviousButton
+    case didTapAcceptButton
+  }
+  
+  init(
+    description: String,
+    nickname: String,
+    valuePicks: [ValuePickModel]
+  ) {
+    self.description = description
+    self.nickname = nickname
+    self.valuePicks = valuePicks
+    self.selectedTab = .all
+    self.displayedValuePicks = valuePicks
+  }
+  
+  let tabs = ValuePickTab.allCases
+  
+  private(set) var navigationTitle: String = Constant.navigationTitle
+  private(set) var description: String
+  private(set) var nickname: String
+  private(set) var contentOffset: CGFloat = 0
+  private(set) var isNameViewVisible: Bool = true
+  private(set) var selectedTab: ValuePickTab
+  private(set) var displayedValuePicks: [ValuePickModel]
+  
+  private var valuePicks: [ValuePickModel]
+
+  
+  func handleAction(_ action: Action) {
+    switch action {
+    case let .contentOffsetDidChange(offset):
+      contentOffset = contentOffset
+      isNameViewVisible = offset > Constant.nameVisibilityOffset
+      
+    case .didTapCloseButton:
+      return
+      
+    case .didTapMoreButton:
+      return
+      
+    case let .didSelectTab(tab):
+      self.selectedTab = tab
+      // TODO: - API 확인 후 displayedValuePicks의 값을 변경하는 로직 추가
+      
+    case .didTapPhotoButton:
+      return
+      
+    case .didTapPreviousButton:
+      return
+      
+    case .didTapAcceptButton:
+      return
+    }
+  }
+}

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickViewModel.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickViewModel.swift
@@ -40,6 +40,7 @@ final class ValuePickViewModel {
     case didTapPhotoButton
     case didTapPreviousButton
     case didTapAcceptButton
+    case didTapDenyButton
   }
   
   init(
@@ -90,6 +91,9 @@ final class ValuePickViewModel {
       return
       
     case .didTapAcceptButton:
+      return
+      
+    case .didTapDenyButton:
       return
     }
   }

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickViewModel.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickViewModel.swift
@@ -7,24 +7,6 @@
 
 import Foundation
 
-enum ValuePickTab: CaseIterable, Identifiable {
-  case all
-  case same
-  case different
-  
-  var id: String {
-    return self.description
-  }
-  
-  var description: String {
-    switch self {
-    case .all: "전체"
-    case .same: "나와 같은"
-    case .different: "나와 다른"
-    }
-  }
-}
-
 @Observable
 final class ValuePickViewModel {
   private enum Constant {

--- a/Tuist/Templates/feature/View.stencil
+++ b/Tuist/Templates/feature/View.stencil
@@ -9,6 +9,8 @@ import SwiftUI
 import DesignSystem
 
 struct {{ name }}View: View {
+  @State var viewModel: {{ name }}ViewModel
+
   var body: some View {
   
   }

--- a/Tuist/Templates/feature/ViewModel.stencil
+++ b/Tuist/Templates/feature/ViewModel.stencil
@@ -7,6 +7,7 @@
 
 import Foundation
 
-final class {{ name }}ViewModel: ObservableObject {
-
+@Observable
+final class {{ name }}ViewModel {
+  enum Action { }
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-196](https://yapp25app3.atlassian.net/browse/PC-196)

## 👷🏼‍♂️ 변경 사항
- 매칭 상세 가치관 Pick UI 구현
- `RoundedButton` 컴포넌트에 `rounding` 속성 추가
- `RoundedButton` 컴포넌트에 `.frame(maxWidth: .infinity)` 제거
  - 버튼이 커져야 할 경우, 해당 컴포넌트를 사용하는 곳에서 `.frame(maxWidth: .infinity)`를 호출합니다.
 
## 💬 참고 사항
- 뭔가 API 나오면 변경 사항이 좀 생길 거 같습니다... 서버에서 `나와 같은`/`나와 다른`을 어떻게 주느냐에 따라 달라질 것 같아요.

## 📸 스크린샷(Optional)
| 스크롤 X | 스크롤 시 | 최하단 스크롤 |
| :--: | :--: | :--: |
| ![image](https://github.com/user-attachments/assets/8cddba16-afc4-435a-a50e-fbbf59ff1d62) | ![image](https://github.com/user-attachments/assets/ef942649-6ad4-4c87-b9db-63a83baecd82) | ![image](https://github.com/user-attachments/assets/4d1e5fb0-f70e-4f43-b2e0-4d2f13b9bd5e) |



[PC-196]: https://yapp25app3.atlassian.net/browse/PC-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ