### PR TITLE
[PC-390] Build: scheme을 dev/prod에서 debug/relesase로 수정

### DIFF
--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,0 +1,78 @@
+{
+  "originHash" : "7737e9f42038e5338de403ce39482b774ce2bf93611806c3fcc74d5ac27d85af",
+  "pins" : [
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "bc92c4b27f9a84bfb498cdbfdf35d5a357e9161f",
+        "version" : "1.5.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "82a4ae7170d98d8538ec77238b7eb8e7199ef2e8",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "e28911721538fa0c2439e92320bad13e3200866f",
+        "version" : "2.2.3"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "8d52279b9809ef27eabe7d5420f03734528f19da",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
+        "version" : "1.4.3"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -2,35 +2,42 @@
 import PackageDescription
 
 #if TUIST
-    import struct ProjectDescription.PackageSettings
+import struct ProjectDescription.PackageSettings
+import ProjectDescriptionHelpers
 
-    let packageSettings = PackageSettings(
-        // Customize the product types for specific package product
-        // Default is .staticFramework
-        // productTypes: ["Alamofire": .framework,]
-        productTypes: [:]
-    )
+let packageSettings = PackageSettings(
+  // Customize the product types for specific package product
+  // Default is .staticFramework
+  // productTypes: ["Alamofire": .framework,]
+  productTypes: [:],
+  baseSettings: .settings()
+//      .settings(
+//    configurations: [
+//      .configuration(environment: .dev),
+//      .configuration(environment: .prod),
+//    ])
+)
 #endif
 
 let package = Package(
-    name: "Piece-iOS",
-    dependencies:
-      ExternalDependency.allCases.map {
-        Package.Dependency.package(
-          url: $0.url,
-          from: $0.version
-        )
-      }
+  name: "Piece-iOS",
+  dependencies:
+    ExternalDependency.allCases.map {
+      Package.Dependency.package(
+        url: $0.url,
+        from: $0.version
+      )
+    }
 )
 
 enum ExternalDependency: String, CaseIterable {
-  case Kingfisher // 예시
+  case SwiftNavigation
 }
 
 extension ExternalDependency {
   var url: String {
     switch self {
-    case .Kingfisher: "https://github.com/onevcat/Kingfisher.git"
+    case .SwiftNavigation: "https://github.com/pointfreeco/swift-navigation"
     }
   }
 }
@@ -38,7 +45,7 @@ extension ExternalDependency {
 extension ExternalDependency {
   var version: PackageDescription.Version {
     switch self {
-    case .Kingfisher: "7.0.0"
+    case .SwiftNavigation: "2.0.0"
     }
   }
 }

--- a/Tuist/ProjectDescriptionHelpers/AppEnvironment.swift
+++ b/Tuist/ProjectDescriptionHelpers/AppEnvironment.swift
@@ -6,12 +6,12 @@
 //
 
 import ProjectDescription
-
-public enum AppEnvironment: String {
-  case dev
-  case prod
-  
-  public var configurationName: ConfigurationName {
-    return ConfigurationName.configuration(self.rawValue)
-  }
-}
+//
+//public enum AppEnvironment: String {
+//  case dev
+//  case prod
+//  
+//  public var configurationName: ConfigurationName {
+//    return ConfigurationName.configuration(self.rawValue)
+//  }
+//}

--- a/Tuist/ProjectDescriptionHelpers/Configuration/Configuration+configuration.swift
+++ b/Tuist/ProjectDescriptionHelpers/Configuration/Configuration+configuration.swift
@@ -6,19 +6,19 @@
 //
 
 import ProjectDescription
-
-// TODO: - xcconfig 경로 추가
-extension Configuration {
-  public static func configuration(environment: AppEnvironment) -> Self {
-    switch environment {
-    case .dev:
-      return .debug(
-        name: environment.configurationName
-      )
-    case .prod:
-      return .release(
-        name: environment.configurationName
-      )
-    }
-  }
-}
+//
+//// TODO: - xcconfig 경로 추가
+//extension Configuration {
+//  public static func configuration(environment: AppEnvironment) -> Self {
+//    switch environment {
+//    case .dev:
+//      return .debug(
+//        name: environment.configurationName
+//      )
+//    case .prod:
+//      return .release(
+//        name: environment.configurationName
+//      )
+//    }
+//  }
+//}

--- a/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+app.swift
@@ -22,12 +22,14 @@ extension Project {
       sources: ["Sources/**"],
       resources: ["Resources/**"],
       dependencies: dependencies,
-      settings: .settings(
-        configurations: [
-          .configuration(environment: .dev),
-          .configuration(environment: .prod),
-        ]
-      ),
+      settings: .settings()
+//          .settings(
+//        configurations: [
+//          .configuration(environment: .dev),
+//          .configuration(environment: .prod),
+//        ]
+//      )
+      ,
       environmentVariables: [:],
       additionalFiles: []
     )
@@ -40,14 +42,16 @@ extension Project {
         developmentRegion: "kor"
       ),
       packages: [],
-      settings: .settings(configurations: [
-        .configuration(environment: .dev),
-        .configuration(environment: .prod),
-      ]),
+      settings: .settings(),
+//          .settings(configurations: [
+//        .configuration(environment: .dev),
+//        .configuration(environment: .prod),
+//      ]),
       targets: [target],
       schemes: [
-        .makeScheme(environment: .dev),
-        .makeScheme(environment: .prod),
+        .makeScheme(),
+//        .makeScheme(environment: .dev),
+//        .makeScheme(environment: .prod),
       ]
     )
   }

--- a/Tuist/ProjectDescriptionHelpers/Project/Project+dynamicFramework.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+dynamicFramework.swift
@@ -32,12 +32,14 @@ extension Project {
     return Project(
       name: name,
       packages: packages,
-      settings: .settings(
-        configurations: [
-          .configuration(environment: .dev),
-          .configuration(environment: .prod),
-        ]
-      ),
+      settings: .settings()
+//          .settings(
+//        configurations: [
+//          .configuration(environment: .dev),
+//          .configuration(environment: .prod),
+//        ]
+//      )
+      ,
       targets: [target]
     )
   }

--- a/Tuist/ProjectDescriptionHelpers/Project/Project+dynamicResourceFramework.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+dynamicResourceFramework.swift
@@ -29,12 +29,14 @@ extension Project {
     return Project(
       name: name,
       packages: packages,
-      settings: .settings(
-        configurations: [
-          .configuration(environment: .dev),
-          .configuration(environment: .prod),
-        ]
-      ),
+      settings: .settings()
+//          .settings(
+//        configurations: [
+//          .configuration(environment: .dev),
+//          .configuration(environment: .prod),
+//        ]
+//      )
+      ,
       targets: [target]
     )
   }

--- a/Tuist/ProjectDescriptionHelpers/Project/Project+staticLibrary.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project/Project+staticLibrary.swift
@@ -28,12 +28,14 @@ extension Project {
     return Project(
       name: name,
       packages: packages,
-      settings: .settings(
-        configurations: [
-          .configuration(environment: .dev),
-          .configuration(environment: .prod),
-        ]
-      ),
+      settings: .settings()
+//          .settings(
+//        configurations: [
+//          .configuration(environment: .dev),
+//          .configuration(environment: .prod),
+//        ]
+//      )
+      ,
       targets: [target]
     )
   }

--- a/Tuist/ProjectDescriptionHelpers/Scheme/Scheme+makeScheme.swift
+++ b/Tuist/ProjectDescriptionHelpers/Scheme/Scheme+makeScheme.swift
@@ -8,14 +8,14 @@
 import ProjectDescription
 
 extension Scheme {
-  public static func makeScheme(environment: AppEnvironment) -> Scheme {
+  public static func makeScheme(/*environment: AppEnvironment*/) -> Scheme {
     return .scheme(
-      name: "\(AppConstants.appName)-\(environment.rawValue)",
+      name: "\(AppConstants.appName)"/*-\(environment.rawValue)*/,
       buildAction: .buildAction(targets: ["\(AppConstants.appName)"]),
-      runAction: .runAction(configuration: environment.configurationName),
-      archiveAction: .archiveAction(configuration: environment.configurationName),
-      profileAction: .profileAction(configuration: environment.configurationName),
-      analyzeAction: .analyzeAction(configuration: environment.configurationName)
+      runAction: .runAction(configuration: "Debug"),// environment.configurationName),
+      archiveAction: .archiveAction(configuration: "Release"), //environment.configurationName),
+      profileAction: .profileAction(configuration: "Release"), //environment.configurationName),
+      analyzeAction: .analyzeAction(configuration: "Debug") //environment.configurationName)
     )
   }
 }

--- a/Tuist/ProjectDescriptionHelpers/Target/TargetDependency+SPM.swift
+++ b/Tuist/ProjectDescriptionHelpers/Target/TargetDependency+SPM.swift
@@ -8,7 +8,7 @@
 import ProjectDescription
 
 public extension TargetDependency {
-  enum SPM {
-    static let Kingfisher     = TargetDependency.external(name: "Kingfisher") // 예시
+  public enum SPM {
+    public static let SwiftNavigation      = TargetDependency.external(name: "SwiftNavigation")
   }
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-390](https://yapp25app3.atlassian.net/browse/PC-390)

## 👷🏼‍♂️ 변경 사항
- AS-IS: scheme을 `dev`/`prod`로 구분하여 빌드 환경(서버 API)를 분리하려 함
  - `swift-navigation` 라이브러리를 사용하여 화면전환 처리를 하려고 하니 다음과 같은 tuist 오류 메시지 발생
```
· The project 'swift-case-paths' has missing or mismatching configurations. It has [Debug (debug), Release (release)], other projects have [dev (debug), prod (release)]
 · The project 'swift-concurrency-extras' has missing or mismatching configurations. It has [Debug (debug), Release (release)], other projects have [dev (debug), prod (release)]
 · The project 'xctest-dynamic-overlay' has missing or mismatching configurations. It has [Debug (debug), Release (release)], other projects have [dev (debug), prod (release)]
 · The project 'swift-custom-dump' has missing or mismatching configurations. It has [Debug (debug), Release (release)], other projects have [dev (debug), prod (release)]
 · No projects found at: Domain/**
 · The project 'swift-collections' has missing or mismatching configurations. It has [Debug (debug), Release (release)], other projects have [dev (debug), prod (release)]
 · The project 'swift-navigation' has missing or mismatching configurations. It has [Debug (debug), Release (release)], other projects have [dev (debug), prod (release)]
 · No projects found at: Data/**
 · The project 'swift-perception' has missing or mismatching configurations. It has [Debug (debug), Release (release)], other projects have [dev (debug), prod (release)]
 · The project 'swift-syntax' has missing or mismatching configurations. It has [Debug (debug), Release (release)], other projects have [dev (debug), prod (release)]
```
그래서 `Package.swift` 파일에 `PackageSettings`의 `baseSettings`를 자체적으로 설정한 configuration인 `dev`와 `prod`로 아래와 같이 설정해줌
```
let packageSettings = PackageSettings(
  productTypes: [:],
  baseSettings: .settings(
    configurations: [
      .configuration(environment: .dev),
      .configuration(environment: .prod),
    ]
  )
)
```
이렇게 해도 실제 프로젝트에서 `@CasePathable` 매크로 사용 시 아래와 같은 문제 발생
```
external macro implementation type 'casepathsmacros.casepathablemacro' could not be found for macro 'casepathable()'; no such file or directory
```
- TO-BE: scheme을 기본값인 `debug`/`release`로 분리
  - 기존 앱 프로젝트와 각 모듈에 설정된 `settings`/`configuration` 값 수정
  - 나중에 참고할 수도 있으니 기존 `scheme`/`settings`/`configuration` 관련 코드는 주석처리

- Reference
  - https://github.com/tuist/tuist/issues/6928 
  - https://github.com/pointfreeco/swift-composable-architecture/discussions/3292#discussioncomment-10592013  

## 💬 참고 사항
- 혹시 이외의 해결방안을 아시는 분 계실까요...?

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-390]: https://yapp25app3.atlassian.net/browse/PC-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ