### PR TITLE
[PC-391] Feat: 회원가입 중 약관동의 UI 구현

### DIFF
--- a/Presentation/Feature/SignUp/Project.swift
+++ b/Presentation/Feature/SignUp/Project.swift
@@ -1,0 +1,18 @@
+//
+//  Project.swift
+//  ProjectDescriptionHelpers
+//
+//  Created by eunseou on 1/12/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.staticLibrary(
+  name: Modules.Presentation.SignUp.rawValue,
+  dependencies: [
+    .presentation(target: .DesignSystem),
+    .utility(target: .PCFoundationExtension)
+  ]
+)
+

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermModel.swift
@@ -1,0 +1,15 @@
+//
+//  TermModel.swift
+//  SignUp
+//
+//  Created by eunseou on 1/16/25.
+//
+
+import SwiftUI
+
+struct TermModel: Identifiable {
+  let id: Int
+  let title: String
+  let url: String
+  var isChecked: Bool
+}

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermModel.swift
@@ -11,5 +11,6 @@ struct TermModel: Identifiable {
   let id: Int
   let title: String
   let url: String
+  let required: Bool
   var isChecked: Bool
 }

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -57,6 +57,7 @@ struct TermsAgreementView: View {
       label: "약관 전체동의",
       isChecked: viewModel.isAllChecked
     )
+    .contentShape(Rectangle())
     .onTapGesture {
       viewModel.handleAction(.toggleAll)
     }

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -115,12 +115,14 @@ struct TermsAgreementView: View {
           id: 0,
           title: "[필수] 서비스 이용약관 동의",
           url: "",
+          required: true,
           isChecked: false
         ),
         TermModel(
           id: 1,
           title: "[필수] 개인정보처리 방침 동의",
           url: "",
+          required: true,
           isChecked: false
         )
       ]

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -53,7 +53,7 @@ struct TermsAgreementView: View {
   }
   
   private var allTermsCheckBox: some View {
-    CheckBox(
+    CheckableTermRow(
       label: "약관 전체동의",
       isChecked: viewModel.isAllChecked
     )
@@ -70,7 +70,7 @@ struct TermsAgreementView: View {
   
   private var termsList: some View {
     ForEach(viewModel.terms) { term in
-      CheckBox(
+      CheckableTermRow(
         label: term.title,
         isChecked: term.isChecked,
         isRequired: term.required,
@@ -90,7 +90,7 @@ struct TermsAgreementView: View {
     )
   }
   
-  private func CheckBox(
+  private func CheckableTermRow(
     label: String,
     isChecked: Bool,
     isRequired: Bool? = nil,

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -15,52 +15,18 @@ struct TermsAgreementView: View {
     ZStack {
       Color.grayscaleWhite.ignoresSafeArea()
       VStack(alignment: .center, spacing: 0) {
-        VStack(alignment: .leading) {
-          Text("Piece의")
-          Text("이용약관")
-            .foregroundStyle(Color.primaryDefault) +
-          Text("을 확인해 주세요")
-        }
-        .pretendard(.heading_L_SB)
-        .foregroundStyle(Color.grayscaleBlack)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        title
         
         Spacer()
           .frame(height: 120)
         
-        CheckBox(
-          label: "약관 전체동의",
-          isChecked: viewModel.isAllChecked
-        )
-        .onTapGesture {
-          viewModel.handleAction(.toggleAll)
-        }
-        .background(
-          Rectangle()
-            .foregroundStyle(Color.grayscaleLight3)
-            .cornerRadius(8)
-        )
-        .padding(.bottom, 12)
+        allTermsCheckBox
         
-        ForEach(viewModel.terms) { term in
-          CheckBox(
-            label: term.title,
-            isChecked: term.isChecked,
-            isRequrired: term.required,
-            tapChevornButton: { viewModel.handleAction(.tapTermURL(url: term.url)) }
-          )
-          .onTapGesture {
-            viewModel.handleAction(.toggleTerm(id: term.id))
-          }
-        }
+        termsList
         
         Spacer()
         
-        RoundedButton(
-          type: viewModel.nextButtonType,
-          buttonText: "다음",
-          action: { viewModel.handleAction(.tapNextButton) }
-        )
+        nextButton
       }
       .padding(.horizontal, 20)
       .padding(.top, 20)
@@ -72,6 +38,56 @@ struct TermsAgreementView: View {
         leftButtonTap: { viewModel.handleAction(.tapBackButton) }
       )
     }
+  }
+  
+  private var title: some View {
+    VStack(alignment: .leading) {
+      Text("Piece의")
+      Text("이용약관")
+        .foregroundStyle(Color.primaryDefault) +
+      Text("을 확인해 주세요")
+    }
+    .pretendard(.heading_L_SB)
+    .foregroundStyle(Color.grayscaleBlack)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+  
+  private var allTermsCheckBox: some View {
+    CheckBox(
+      label: "약관 전체동의",
+      isChecked: viewModel.isAllChecked
+    )
+    .onTapGesture {
+      viewModel.handleAction(.toggleAll)
+    }
+    .background(
+      Rectangle()
+        .foregroundStyle(Color.grayscaleLight3)
+        .cornerRadius(8)
+    )
+    .padding(.bottom, 12)
+  }
+  
+  private var termsList: some View {
+    ForEach(viewModel.terms) { term in
+      CheckBox(
+        label: term.title,
+        isChecked: term.isChecked,
+        isRequrired: term.required,
+        tapChevornButton: { viewModel.handleAction(.tapTermURL(url: term.url)) }
+      )
+      .onTapGesture {
+        viewModel.handleAction(.toggleTerm(id: term.id))
+      }
+    }
+  }
+  
+  private var nextButton: some View {
+    RoundedButton(
+      type: viewModel.nextButtonType,
+      buttonText: "다음",
+      action: { viewModel.handleAction(.tapNextButton) }
+    )
   }
   
   private func CheckBox(

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -20,7 +20,7 @@ struct TermsAgreementView: View {
         Spacer()
           .frame(height: 120)
         
-        allTermsCheckBox
+        allTermsCheckableRow
         
         termsList
         
@@ -52,7 +52,7 @@ struct TermsAgreementView: View {
     .frame(maxWidth: .infinity, alignment: .leading)
   }
   
-  private var allTermsCheckBox: some View {
+  private var allTermsCheckableRow: some View {
     CheckableTermRow(
       label: "약관 전체동의",
       isChecked: viewModel.isAllChecked

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -73,7 +73,7 @@ struct TermsAgreementView: View {
       CheckBox(
         label: term.title,
         isChecked: term.isChecked,
-        isRequrired: term.required,
+        isRequired: term.required,
         tapChevornButton: { viewModel.handleAction(.tapTermURL(url: term.url)) }
       )
       .onTapGesture {
@@ -93,7 +93,7 @@ struct TermsAgreementView: View {
   private func CheckBox(
     label: String,
     isChecked: Bool,
-    isRequrired: Bool? = nil,
+    isRequired: Bool? = nil,
     tapChevornButton: (()->Void)? = nil
   ) -> some View {
     HStack {
@@ -101,7 +101,7 @@ struct TermsAgreementView: View {
         .renderingMode(.template)
         .foregroundStyle(isChecked ? Color.primaryDefault : Color.grayscaleLight1)
       
-      Text(isRequiredText(isRequrired) + label)
+      Text(isRequiredText(isRequired) + label)
         .pretendard(.body_M_R)
         .foregroundStyle(Color.grayscaleBlack)
       

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -1,0 +1,129 @@
+//
+//  TermsAgreementView.swift
+//  Login
+//
+//  Created by eunseou on 1/12/25.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct TermsAgreementView: View {
+  @State var viewModel: TermsAgreementViewModel
+  
+  var body: some View {
+    ZStack {
+      Color.grayscaleWhite.ignoresSafeArea()
+      VStack(alignment: .center, spacing: 0) {
+        VStack(alignment: .leading) {
+          Text("Piece의")
+          Text("이용약관")
+            .foregroundStyle(Color.primaryDefault) +
+          Text("을 확인해 주세요")
+        }
+        .pretendard(.heading_L_SB)
+        .foregroundStyle(Color.grayscaleBlack)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        
+        Spacer()
+          .frame(height: 120)
+        
+        CheckBox(
+          label: "약관 전체동의",
+          isChecked: viewModel.isAllChecked,
+          tapCheckButton: { viewModel.handleAction(.toggleAll)},
+          backgoundColor: .grayscaleLight3
+        )
+        .padding(.bottom, 12)
+        
+        ForEach(viewModel.terms) { term in
+          CheckBox(
+            label: term.title,
+            isChecked: term.isChecked,
+            tapCheckButton: { viewModel.handleAction(.toggleTerm(id: term.id))},
+            tapChevornButton: { viewModel.handleAction(.tapTermURL(url: term.url)) }
+          )
+        }
+        
+        Spacer()
+        
+        RoundedButton(
+          type: viewModel.nextButtonType,
+          buttonText: "다음",
+          action: { viewModel.handleAction(.tapNextButton) }
+        )
+      }
+      .padding(.horizontal, 20)
+      .padding(.top, 20)
+      .padding(.bottom, 10)
+    }
+    .navigationBarModifier {
+      NavigationBar(
+        title: "",
+        leftButtonTap: { viewModel.handleAction(.tapBackButton) }
+      )
+    }
+  }
+  
+  private func CheckBox(
+    label: String,
+    isChecked: Bool,
+    tapCheckButton: @escaping () -> Void,
+    backgoundColor: Color? = .clear,
+    tapChevornButton: (()->Void)? = nil
+  ) -> some View {
+    HStack {
+      Button{
+        tapCheckButton()
+      } label: {
+        DesignSystemAsset.Icons.checkCircle20.swiftUIImage
+          .renderingMode(.template)
+          .foregroundStyle(isChecked ? Color.primaryDefault : Color.grayscaleLight1)
+      }
+      Text(label)
+        .pretendard(.body_M_R)
+        .foregroundStyle(Color.grayscaleBlack)
+      
+      Spacer()
+      
+      if let tapChevornButton {
+        Button {
+          tapChevornButton()
+        } label: {
+          DesignSystemAsset.Icons.chevronRight24.swiftUIImage
+            .renderingMode(.template)
+            .foregroundStyle(Color.grayscaleDark3)
+        }
+      }
+    }
+    .padding(.vertical, 14)
+    .padding(.horizontal, 14)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(
+      Rectangle()
+        .foregroundStyle(backgoundColor ?? .clear)
+        .cornerRadius(8)
+    )
+  }
+}
+
+#Preview {
+  TermsAgreementView(
+    viewModel: TermsAgreementViewModel(
+      terms: [
+        TermModel(
+          id: 0,
+          title: "[필수] 서비스 이용약관 동의",
+          url: "",
+          isChecked: false
+        ),
+        TermModel(
+          id: 1,
+          title: "[필수] 개인정보처리 방침 동의",
+          url: "",
+          isChecked: false
+        )
+      ]
+    )
+  )
+}

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -30,9 +30,15 @@ struct TermsAgreementView: View {
         
         CheckBox(
           label: "약관 전체동의",
-          isChecked: viewModel.isAllChecked,
-          tapCheckButton: { viewModel.handleAction(.toggleAll)},
-          backgoundColor: .grayscaleLight3
+          isChecked: viewModel.isAllChecked
+        )
+        .onTapGesture {
+          viewModel.handleAction(.toggleAll)
+        }
+        .background(
+          Rectangle()
+            .foregroundStyle(Color.grayscaleLight3)
+            .cornerRadius(8)
         )
         .padding(.bottom, 12)
         
@@ -41,9 +47,11 @@ struct TermsAgreementView: View {
             label: term.title,
             isChecked: term.isChecked,
             isRequrired: term.required,
-            tapCheckButton: { viewModel.handleAction(.toggleTerm(id: term.id))},
             tapChevornButton: { viewModel.handleAction(.tapTermURL(url: term.url)) }
           )
+          .onTapGesture {
+            viewModel.handleAction(.toggleTerm(id: term.id))
+          }
         }
         
         Spacer()
@@ -70,18 +78,12 @@ struct TermsAgreementView: View {
     label: String,
     isChecked: Bool,
     isRequrired: Bool? = nil,
-    tapCheckButton: @escaping () -> Void,
-    backgoundColor: Color? = .clear,
     tapChevornButton: (()->Void)? = nil
   ) -> some View {
     HStack {
-      Button{
-        tapCheckButton()
-      } label: {
-        DesignSystemAsset.Icons.checkCircle20.swiftUIImage
-          .renderingMode(.template)
-          .foregroundStyle(isChecked ? Color.primaryDefault : Color.grayscaleLight1)
-      }
+      DesignSystemAsset.Icons.checkCircle20.swiftUIImage
+        .renderingMode(.template)
+        .foregroundStyle(isChecked ? Color.primaryDefault : Color.grayscaleLight1)
       
       Text(isRequiredText(isRequrired) + label)
         .pretendard(.body_M_R)
@@ -102,11 +104,6 @@ struct TermsAgreementView: View {
     .padding(.vertical, 14)
     .padding(.horizontal, 14)
     .frame(maxWidth: .infinity, alignment: .leading)
-    .background(
-      Rectangle()
-        .foregroundStyle(backgoundColor ?? .clear)
-        .cornerRadius(8)
-    )
   }
   
   private func isRequiredText(_ isRequired: Bool?) -> String {

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -40,6 +40,7 @@ struct TermsAgreementView: View {
           CheckBox(
             label: term.title,
             isChecked: term.isChecked,
+            isRequrired: term.required,
             tapCheckButton: { viewModel.handleAction(.toggleTerm(id: term.id))},
             tapChevornButton: { viewModel.handleAction(.tapTermURL(url: term.url)) }
           )
@@ -68,6 +69,7 @@ struct TermsAgreementView: View {
   private func CheckBox(
     label: String,
     isChecked: Bool,
+    isRequrired: Bool? = nil,
     tapCheckButton: @escaping () -> Void,
     backgoundColor: Color? = .clear,
     tapChevornButton: (()->Void)? = nil
@@ -80,7 +82,8 @@ struct TermsAgreementView: View {
           .renderingMode(.template)
           .foregroundStyle(isChecked ? Color.primaryDefault : Color.grayscaleLight1)
       }
-      Text(label)
+      
+      Text(isRequiredText(isRequrired) + label)
         .pretendard(.body_M_R)
         .foregroundStyle(Color.grayscaleBlack)
       
@@ -105,6 +108,11 @@ struct TermsAgreementView: View {
         .cornerRadius(8)
     )
   }
+  
+  private func isRequiredText(_ isRequired: Bool?) -> String {
+    guard let isRequired = isRequired else { return "" }
+    return isRequired ? "[필수] " : "[선택] "
+  }
 }
 
 #Preview {
@@ -113,14 +121,14 @@ struct TermsAgreementView: View {
       terms: [
         TermModel(
           id: 0,
-          title: "[필수] 서비스 이용약관 동의",
+          title: "서비스 이용약관 동의",
           url: "",
           required: true,
           isChecked: false
         ),
         TermModel(
           id: 1,
-          title: "[필수] 개인정보처리 방침 동의",
+          title: "개인정보처리 방침 동의",
           url: "",
           required: true,
           isChecked: false

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementViewModel.swift
@@ -1,0 +1,49 @@
+//
+//  TermsOfServiceViewModel.swift
+//  SignUp
+//
+//  Created by eunseou on 1/15/25.
+//
+
+import SwiftUI
+import Observation
+import DesignSystem
+
+@Observable
+final class TermsAgreementViewModel {
+  enum Action {
+    case toggleAll
+    case toggleTerm(id: Int)
+    case tapTermURL(url: String)
+    case tapNextButton
+    case tapBackButton
+  }
+  
+  init(terms: [TermModel]) {
+    self.terms = terms
+  }
+  
+  var terms: [TermModel]
+  var isAllChecked: Bool {
+    terms.allSatisfy { $0.isChecked }
+  }
+  var nextButtonType: RoundedButton.ButtonType {
+    isAllChecked ? .solid : .disabled
+  }
+  
+  func handleAction(_ action: Action) {
+    switch action {
+    case .toggleAll:
+      let newState = !isAllChecked
+      terms.indices.forEach {
+        terms[$0].isChecked = newState
+      }
+    case .toggleTerm(let id):
+      if let index = terms.firstIndex(where: { $0.id == id }) {
+        terms[index].isChecked.toggle()
+      }
+    default:
+      return
+    }
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/Modules.swift
+++ b/Tuist/ProjectDescriptionHelpers/Modules.swift
@@ -74,6 +74,7 @@ public extension Modules {
   enum Presentation: String {
     case DesignSystem
     case Login
+    case SignUp
     case MatchingMain
     
     var path: String {


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-391](https://yapp25app3.atlassian.net/browse/PC-391)

## 👷🏼‍♂️ 변경 사항
- Presentation > SignUp 모듈 생성
- 회원가입 중 약관동의 뷰 구현


## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
| <img width="240" alt="image" src="https://github.com/user-attachments/assets/2ba14290-4d53-479e-9aad-f17794aaa627" /> |

[PC-391]: https://yapp25app3.atlassian.net/browse/PC-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ