### PR TITLE
[PC-392] Feat: 약관 상세 웹뷰 UI 구현

### DIFF
--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermModel.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct TermModel: Identifiable {
+struct TermModel: Identifiable, Hashable {
   let id: Int
   let title: String
   let url: String

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -43,7 +43,8 @@ struct TermsAgreementView: View {
         if let index = viewModel.terms.firstIndex(where: { $0.id == term.id }) {
           TermsWebView(
             viewModel: TermsWebViewModel(
-              term: viewModel.terms[index]
+              term: viewModel.terms[index],
+              checkTerm: { viewModel.terms[index] = $0 }
             )
           )
         } else {

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -74,7 +74,7 @@ struct TermsAgreementView: View {
         label: term.title,
         isChecked: term.isChecked,
         isRequrired: term.required,
-        tapChevornButton: { viewModel.handleAction(.tapTermURL(url: term.url)) }
+        tapChevornButton: { viewModel.handleAction(.tapChevronButton) }
       )
       .onTapGesture {
         viewModel.handleAction(.toggleTerm(id: term.id))

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -135,14 +135,14 @@ struct TermsAgreementView: View {
         TermModel(
           id: 0,
           title: "서비스 이용약관 동의",
-          url: "",
+          url: "https://brassy-client-c0a.notion.site/16a2f1c4b966800f923cd499d8e07a97",
           required: true,
           isChecked: false
         ),
         TermModel(
           id: 1,
           title: "개인정보처리 방침 동의",
-          url: "",
+          url: "https://brassy-client-c0a.notion.site/16a2f1c4b96680f8b622e5925a394edf?pvs=4",
           required: true,
           isChecked: false
         )

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementView.swift
@@ -12,31 +12,44 @@ struct TermsAgreementView: View {
   @State var viewModel: TermsAgreementViewModel
   
   var body: some View {
-    ZStack {
-      Color.grayscaleWhite.ignoresSafeArea()
-      VStack(alignment: .center, spacing: 0) {
-        title
-        
-        Spacer()
-          .frame(height: 120)
-        
-        allTermsCheckBox
-        
-        termsList
-        
-        Spacer()
-        
-        nextButton
+    NavigationStack(path: $viewModel.navigationPath){
+      ZStack {
+        Color.grayscaleWhite.ignoresSafeArea()
+        VStack(alignment: .center, spacing: 0) {
+          title
+          
+          Spacer()
+            .frame(height: 120)
+          
+          allTermsCheckBox
+          
+          termsList
+          
+          Spacer()
+          
+          nextButton
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 20)
+        .padding(.bottom, 10)
       }
-      .padding(.horizontal, 20)
-      .padding(.top, 20)
-      .padding(.bottom, 10)
-    }
-    .navigationBarModifier {
-      NavigationBar(
-        title: "",
-        leftButtonTap: { viewModel.handleAction(.tapBackButton) }
-      )
+      .navigationBarModifier {
+        NavigationBar(
+          title: "",
+          leftButtonTap: { viewModel.handleAction(.tapBackButton) }
+        )
+      }
+      .navigationDestination(for: TermModel.self) { term in
+        if let index = viewModel.terms.firstIndex(where: { $0.id == term.id }) {
+          TermsWebView(
+            viewModel: TermsWebViewModel(
+              term: viewModel.terms[index]
+            )
+          )
+        } else {
+          Text("약관을 찾을 수 없습니다.")
+        }
+      }
     }
   }
   
@@ -74,7 +87,7 @@ struct TermsAgreementView: View {
         label: term.title,
         isChecked: term.isChecked,
         isRequrired: term.required,
-        tapChevornButton: { viewModel.handleAction(.tapChevronButton) }
+        tapChevornButton: { viewModel.handleAction(.tapChevronButton(with: term)) }
       )
       .onTapGesture {
         viewModel.handleAction(.toggleTerm(id: term.id))
@@ -146,7 +159,8 @@ struct TermsAgreementView: View {
           required: true,
           isChecked: false
         )
-      ]
+      ],
+      navigationPath: NavigationPath()
     )
   )
 }

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementViewModel.swift
@@ -14,7 +14,7 @@ final class TermsAgreementViewModel {
   enum Action {
     case toggleAll
     case toggleTerm(id: Int)
-    case tapTermURL(url: String)
+    case tapChevronButton
     case tapNextButton
     case tapBackButton
   }

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsAgreementViewModel.swift
@@ -14,16 +14,21 @@ final class TermsAgreementViewModel {
   enum Action {
     case toggleAll
     case toggleTerm(id: Int)
-    case tapChevronButton
+    case tapChevronButton(with: TermModel)
     case tapNextButton
     case tapBackButton
   }
   
-  init(terms: [TermModel]) {
+  init(
+    terms: [TermModel],
+    navigationPath: NavigationPath
+  ) {
     self.terms = terms
+    self.navigationPath = navigationPath
   }
   
   var terms: [TermModel]
+  var navigationPath: NavigationPath
   var isAllChecked: Bool {
     terms.allSatisfy { $0.isChecked }
   }
@@ -42,6 +47,8 @@ final class TermsAgreementViewModel {
       if let index = terms.firstIndex(where: { $0.id == id }) {
         terms[index].isChecked.toggle()
       }
+    case .tapChevronButton(let term):
+      navigationPath.append(term)
     default:
       return
     }

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebView.swift
@@ -1,0 +1,52 @@
+//
+//  TermsWebView.swift
+//  SignUp
+//
+//  Created by eunseou on 1/17/25.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct TermsWebView: View {
+  @State var viewModel: TermsWebViewModel
+  
+  var body: some View {
+    ZStack {
+      WebView(urlString: viewModel.term.url)
+        .padding(.bottom, 74)
+      
+      VStack {
+        Spacer()
+        
+        RoundedButton(
+          type: .solid,
+          buttonText: "동의하기",
+          action: { viewModel.handleAction(.tapAgreementButton) }
+        )
+      }
+      .padding(.horizontal, 20)
+      .padding(.bottom, 10)
+    }
+    .navigationBarModifier {
+      NavigationBar(
+        title: viewModel.term.title,
+        leftButtonTap: { viewModel.handleAction(.tapBackButton) }
+      )
+    }
+  }
+}
+
+#Preview {
+  TermsWebView(
+    viewModel: TermsWebViewModel(
+      term: TermModel(
+        id: 0,
+        title: "서비스 이용약관",
+        url: "https://brassy-client-c0a.notion.site/16a2f1c4b966800f923cd499d8e07a97",
+        required: true,
+        isChecked: false
+      )
+    )
+  )
+}

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebView.swift
@@ -10,6 +10,7 @@ import DesignSystem
 
 struct TermsWebView: View {
   @State var viewModel: TermsWebViewModel
+  @Environment(\.dismiss) private var dismiss
   
   var body: some View {
     ZStack {
@@ -33,6 +34,9 @@ struct TermsWebView: View {
         title: viewModel.term.title,
         leftButtonTap: { viewModel.handleAction(.tapBackButton) }
       )
+    }
+    .onAppear {
+      viewModel.setDismissAction { dismiss() }
     }
   }
 }

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebViewModel.swift
@@ -14,8 +14,9 @@ final class TermsWebViewModel {
     case tapAgreementButton
     case tapBackButton
   }
-    
+  
   var term: TermModel
+  private var dismissAction: (() -> Void)?
   
   init(term: TermModel) {
     self.term = term
@@ -23,7 +24,14 @@ final class TermsWebViewModel {
   
   func handleAction(_ action: Action) {
     switch action {
-    default: return
+    case .tapBackButton:
+      dismissAction?()
+    case .tapAgreementButton:
+      return
     }
+  }
+  
+  func setDismissAction(_ dismiss: @escaping () -> Void) {
+    self.dismissAction = dismiss
   }
 }

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebViewModel.swift
@@ -1,0 +1,29 @@
+//
+//  TermsWebViewModel.swift
+//  SignUp
+//
+//  Created by eunseou on 1/17/25.
+//
+
+import SwiftUI
+import Observation
+
+@Observable
+final class TermsWebViewModel {
+  enum Action {
+    case tapAgreementButton
+    case tapBackButton
+  }
+    
+  var term: TermModel
+  
+  init(term: TermModel) {
+    self.term = term
+  }
+  
+  func handleAction(_ action: Action) {
+    switch action {
+    default: return
+    }
+  }
+}

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/TermsWebViewModel.swift
@@ -16,10 +16,15 @@ final class TermsWebViewModel {
   }
   
   var term: TermModel
+  var checkTerm: ((TermModel) -> Void)?
   private var dismissAction: (() -> Void)?
   
-  init(term: TermModel) {
+  init(
+    term: TermModel,
+    checkTerm: ((TermModel) -> Void)? = nil
+  ) {
     self.term = term
+    self.checkTerm = checkTerm
   }
   
   func handleAction(_ action: Action) {
@@ -27,7 +32,9 @@ final class TermsWebViewModel {
     case .tapBackButton:
       dismissAction?()
     case .tapAgreementButton:
-      return
+      term.isChecked = true
+      checkTerm?(term)
+      dismissAction?()
     }
   }
   

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/WebView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/WebView.swift
@@ -12,12 +12,18 @@ struct WebView: UIViewRepresentable {
   let urlString: String
   
   func makeUIView(context: Context) -> WKWebView {
-    return WKWebView()
+    let webView = WKWebView()
+    if let url = URL(string: urlString) {
+      let request = URLRequest(url: url)
+      webView.load(request)
+    }
+    return webView
   }
   
   func updateUIView(_ uiView: WKWebView, context: Context) {
-    guard let url = URL(string: urlString) else { return }
-    let request = URLRequest(url: url)
-    uiView.load(request)
+    if let url = URL(string: urlString), url != uiView.url {
+      let request = URLRequest(url: url)
+      uiView.load(request)
+    }
   }
 }

--- a/Presentation/Feature/SignUp/Sources/TermsAgreement/WebView.swift
+++ b/Presentation/Feature/SignUp/Sources/TermsAgreement/WebView.swift
@@ -1,0 +1,23 @@
+//
+//  WebView.swift
+//  SignUp
+//
+//  Created by eunseou on 1/20/25.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+  let urlString: String
+  
+  func makeUIView(context: Context) -> WKWebView {
+    return WKWebView()
+  }
+  
+  func updateUIView(_ uiView: WKWebView, context: Context) {
+    guard let url = URL(string: urlString) else { return }
+    let request = URLRequest(url: url)
+    uiView.load(request)
+  }
+}


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-392](https://yapp25app3.atlassian.net/browse/PC-392)

## 👷🏼‍♂️ 변경 사항
- **`WebView` 파일 생성** : UIViewRepresentable를 상속한 웹뷰는 url을 주입받아 해당 웹뷰를 띄웁니다.
- **`TermWebView`파일 생성** : `WebView`를 ZStack 레이어 가장 하단에 깔고, 그 위에 `nextButton`을 올렸습니다.
- **`TermModel`에 Hashable 프로토콜 추가** :  NavigationStack에서 처리할 데이터의 타입을 위해 추가했습니다.
 
## 💬 참고 사항
- 하나의 PR에 너무 많은 내용이 있어 가독성이 떨어질까 생각해, 이전 PR 브랜치에서 따와 새 PR을 작성했습니다!
- 약관의 내용을 확인할 수 있는 상세 약관 웹뷰를 구현했습니다.
- 클로저를 사용해서 '동의하기' 버튼을 눌렀을 때, `TermsAgreementView`에 데이터가 반영되도록했습니다.
- `TermsAgreementView` Preview에서 아래 내용을 확인할 수 있습니다
    -  [chevron 버튼을 눌러 해당하는 상세약관을 확인할 수 있다.]
    -  [체크 버튼 + 텍스트 영역을 눌러 약관을 동의할 수 있다.]
    -  [상세약관 웹뷰에서 동의하기 버튼을 누르면 이전뷰로 돌아간다. 이때 돌아온 뷰의 약관에 isChecked 속성이 반영된다.]
    -  [모든 약관이 동의되어야만 다음 버튼이 활성화된다]


## 📸 스크린샷(Optional)
| TermsAgreementView -> TermWebView |
| :--: |
| <img width=375 alt="TermsAgreementView -> TermWebView'" src="https://github.com/user-attachments/assets/1989db88-81f9-42b7-92aa-d0c3f0beac76" /> |

[PC-334]: https://yapp25app3.atlassian.net/browse/PC-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PC-392]: https://yapp25app3.atlassian.net/browse/PC-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ