### PR TITLE
[PC-447] Feat: 앱 홈 화면 구현

### DIFF
--- a/App/Sources/ContentView.swift
+++ b/App/Sources/ContentView.swift
@@ -8,8 +8,7 @@ struct ContentView: View {
   var body: some View {
     // TODO: - Splash 화면으로 변경
     NavigationStack(path: $router.path) {
-      Rectangle()
-        .fill(.yellow)
+      Coordinator.view(for: .home)
         .navigationDestination(for: Route.self) { route in
           Coordinator.view(for: route)
         }

--- a/Presentation/Coordinator/Project.swift
+++ b/Presentation/Coordinator/Project.swift
@@ -12,6 +12,7 @@ let project = Project.dynamicFramework(
   dependencies: [
     .domain(target: .UseCases),
     .presentation(target: .Router),
+    .presentation(target: .Home),
     .presentation(target: .MatchingDetail),
   ]
 )

--- a/Presentation/Coordinator/Sources/Coordinator.swift
+++ b/Presentation/Coordinator/Sources/Coordinator.swift
@@ -6,6 +6,7 @@
 //
 
 import MatchingDetail
+import Home
 import Router
 import SwiftUI
 import UseCases
@@ -14,6 +15,8 @@ public struct Coordinator {
   @ViewBuilder
   public static func view(for route: Route) -> some View {
     switch route {
+    case .home:
+      HomeViewFactory.createHomeView()
     case .matchProfileBasic:
       let getMatchProfileBasicUseCase = UseCaseFactory.createGetMatchProfileBasicUseCase()
       MatchDetailViewFactory.createMatchProfileBasicView(getMatchProfileBasicUseCase: getMatchProfileBasicUseCase)

--- a/Presentation/DesignSystem/Sources/TabBarView.swift
+++ b/Presentation/DesignSystem/Sources/TabBarView.swift
@@ -5,11 +5,12 @@
 //  Created by eunseou on 12/28/24.
 //
 
+import Observation
 import SwiftUI
 
 // MARK: - 탭바 뷰
 public struct TabBarView: View {
-  @ObservedObject private var viewModel: TabBarViewModel
+  @State private var viewModel: TabBarViewModel
   
   public init(
     viewModel: TabBarViewModel
@@ -60,8 +61,9 @@ public struct TabBarView: View {
 }
 
 // MARK: - 탭바 뷰모델 (임시)
-public class TabBarViewModel: ObservableObject {
-  @Published var selectedTab: Tab = .home
+@Observable
+public class TabBarViewModel {
+  public var selectedTab: Tab = .home
   
   public init() { }
   

--- a/Presentation/Feature/Home/Project.swift
+++ b/Presentation/Feature/Home/Project.swift
@@ -1,0 +1,18 @@
+//
+// Project.swift
+// Home
+//
+// Created by summercat on 2025/01/30.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.staticLibrary(
+  name: Modules.Presentation.Home.rawValue,
+  dependencies: [
+    .presentation(target: .DesignSystem),
+    .presentation(target: .Router),
+    .presentation(target: .MatchingMain),
+  ]
+)

--- a/Presentation/Feature/Home/Sources/HomeView.swift
+++ b/Presentation/Feature/Home/Sources/HomeView.swift
@@ -1,0 +1,42 @@
+//
+// HomeView.swift
+// Home
+//
+// Created by summercat on 2025/01/30.
+//
+
+import DesignSystem
+import MatchingMain
+import SwiftUI
+
+struct HomeView: View {
+  @State var viewModel: HomeViewModel
+
+  var body: some View {
+    ZStack {
+      content
+      TabBarView(viewModel: viewModel.tabbarViewModel)
+    }
+  }
+  
+  private var content: some View {
+    switch viewModel.tabbarViewModel.selectedTab {
+    case .profile:
+      // TODO: - ProfileView
+      Rectangle()
+        .fill(Color.yellow)
+    case .home:
+      // TODO: - MatchingMainView
+      Rectangle()
+        .fill(Color.red)
+    case .settings:
+      // TODO: - SettingsView
+      Rectangle()
+        .fill(Color.blue)
+    }
+  }
+}
+
+#Preview {
+  HomeView(viewModel: HomeViewModel())
+}

--- a/Presentation/Feature/Home/Sources/HomeViewFactory.swift
+++ b/Presentation/Feature/Home/Sources/HomeViewFactory.swift
@@ -1,0 +1,15 @@
+//
+//  HomeViewFactory.swift
+//  Home
+//
+//  Created by summercat on 1/30/25.
+//
+
+import SwiftUI
+
+public struct HomeViewFactory {
+  @ViewBuilder
+  public static func createHomeView() -> some View {
+    HomeView(viewModel: HomeViewModel())
+  }
+}

--- a/Presentation/Feature/Home/Sources/HomeViewModel.swift
+++ b/Presentation/Feature/Home/Sources/HomeViewModel.swift
@@ -1,0 +1,19 @@
+//
+// HomeViewModel.swift
+// Home
+//
+// Created by summercat on 2025/01/30.
+//
+
+import DesignSystem
+import Observation
+import SwiftUI
+
+@Observable
+final class HomeViewModel {
+  enum Action { }
+  
+  init() { }
+  
+  let tabbarViewModel = TabBarViewModel()
+}

--- a/Presentation/Router/Sources/Route.swift
+++ b/Presentation/Router/Sources/Route.swift
@@ -6,6 +6,7 @@
 //
 
 public enum Route: Hashable {
+  case home
   case matchProfileBasic
   case matchValueTalk
   case matchValuePick

--- a/Tuist/ProjectDescriptionHelpers/Modules.swift
+++ b/Tuist/ProjectDescriptionHelpers/Modules.swift
@@ -74,6 +74,7 @@ public extension Modules {
     case Coordinator
     case Login
     case SignUp
+    case Home
     case MatchingMain
     case MatchingDetail
     


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-447](https://yapp25app3.atlassian.net/browse/PC-447)

## 👷🏼‍♂️ 변경 사항
- 홈 화면의 탭을 담는 Container 역할을 하는 화면 구현
- 개발상의 편의를 위해 앱 실행 시 홈 화면으로 라우팅 되도록 앱 모듈의 `ContentView` 수정
  - 추후 `Splash` 화면 개발 시, `Splash`에서 `Onboarding` 또는 `Home`으로 분기 처리 로직 추가 예정
- `TabbarView`에서 `ObservableObject` 대신 `@Observable`을 사용하도록 변경
  - `ObservableObject` 사용 시, `@Observable`을 사용하는 Feature에서 `ObservableObject`의 변경사항을 제대로 감지하지 못하는 이슈 발생
  
## 💬 참고 사항
-

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-447]: https://yapp25app3.atlassian.net/browse/PC-447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ