### PR TITLE
[PC-449] Fix: Router의 PopToMain 메서드 삭제

### DIFF
--- a/Presentation/Feature/MatchingDetail/Sources/MatchProfileBasic/MatchProfileBasicView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/MatchProfileBasic/MatchProfileBasicView.swift
@@ -37,7 +37,7 @@ struct MatchProfileBasicView: View {
       NavigationBar(
         title: viewModel.navigationTitle,
         rightButtonTap: {
-          router.popToMain()
+          router.popToRoot()
         })
       
       VStack(alignment: .leading) {

--- a/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValuePick/ValuePickView.swift
@@ -31,7 +31,7 @@ struct ValuePickView: View {
         title: viewModel.navigationTitle,
         titleColor: .grayscaleBlack,
         rightButtonTap: {
-          router.popToMain()
+          router.popToRoot()
         },
         backgroundColor: .grayscaleWhite
       )
@@ -74,6 +74,7 @@ struct ValuePickView: View {
       
       bottomButtons
     }
+    .toolbar(.hidden)
   }
   
   // MARK: - 탭

--- a/Presentation/Feature/MatchingDetail/Sources/ValueTalk/ValueTalkView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/ValueTalk/ValueTalkView.swift
@@ -38,7 +38,7 @@ struct ValueTalkView: View {
         title: viewModel.navigationTitle,
         titleColor: .grayscaleBlack,
         rightButtonTap: {
-          router.popToMain()
+          router.popToRoot()
         },
         backgroundColor: .grayscaleWhite
       )

--- a/Presentation/Router/Sources/Router.swift
+++ b/Presentation/Router/Sources/Router.swift
@@ -25,8 +25,4 @@ public final class Router {
   public func popToRoot() {
     path.removeLast(path.count)
   }
-  
-  public func popToMain() {
-    path.removeLast(path.count - 1)
-  }
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-449](https://yapp25app3.atlassian.net/browse/PC-449)

## 👷🏼‍♂️ 변경 사항
- 홈 탭에 있는 화면은 Router의 path에 추가되어 있지 않은 상태이므로, popToRoot를 해야 메인 화면으로 갈 수 있다.
 
## 💬 참고 사항
- 큰 변경사항이 없어 머지합니다.

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |