### PR TITLE
[PC-199] 매칭 상세 - 프로필 사진 화면 구현, alert modifier 구현

### DIFF
--- a/Presentation/DesignSystem/Sources/AlertView.swift
+++ b/Presentation/DesignSystem/Sources/AlertView.swift
@@ -88,6 +88,7 @@ private struct AlertBottomView: View {
         type: .outline,
         buttonText: firstButtonText,
         icon: nil,
+        width: .maxWidth,
         height: 52,
         action: firstButtonAction
       )
@@ -95,6 +96,7 @@ private struct AlertBottomView: View {
         type: .solid,
         buttonText: secondButtonText,
         icon: nil,
+        width: .maxWidth,
         height: 52,
         action: secondButtonAction
       )

--- a/Presentation/DesignSystem/Sources/Dimmer.swift
+++ b/Presentation/DesignSystem/Sources/Dimmer.swift
@@ -1,0 +1,23 @@
+//
+//  Dimmer.swift
+//  DesignSystem
+//
+//  Created by summercat on 1/30/25.
+//
+
+import SwiftUI
+
+public struct Dimmer: View {
+  public init() { }
+  
+  public var body: some View {
+    Rectangle()
+      .fill(Color.alphaBlack40)
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .ignoresSafeArea()
+  }
+}
+
+#Preview {
+  Dimmer()
+}

--- a/Presentation/DesignSystem/Sources/RoundedButton.swift
+++ b/Presentation/DesignSystem/Sources/RoundedButton.swift
@@ -42,10 +42,16 @@ public struct RoundedButton: View {
     }
   }
   
+  public enum ButtonWidth: Equatable {
+    case contentSize
+    case maxWidth
+  }
+  
   public init(
     type: ButtonType,
     buttonText: String,
     icon: Image? = nil,
+    width: ButtonWidth = .contentSize,
     height: CGFloat? = 52,
     rounding: Bool = false,
     action: @escaping () -> Void
@@ -53,6 +59,7 @@ public struct RoundedButton: View {
     self.type = type
     self.buttonText = buttonText
     self.icon = icon
+    self.width = width
     self.height = height
     self.rounding = rounding
     self.action = action
@@ -72,6 +79,7 @@ public struct RoundedButton: View {
           .pretendard(.body_M_SB)
           .foregroundStyle(type.contentColor)
       }
+      .frame(maxWidth: width == .maxWidth ? .infinity : nil)
       .frame(height: height)
       .padding(.horizontal, rounding ? 28 : 12)
       .background(
@@ -109,6 +117,7 @@ public struct RoundedButton: View {
   private let type: ButtonType
   private let buttonText: String
   private let icon: Image?
+  private let width: ButtonWidth
   private let height: CGFloat?
   private let rounding: Bool
   private let action: () -> Void
@@ -120,6 +129,7 @@ public struct RoundedButton: View {
       type: .solid,
       buttonText: "Solid",
       icon: nil,
+      width: .maxWidth,
       rounding: true,
       action: {
       })

--- a/Presentation/DesignSystem/Sources/ViewModifiers/AlertModifier.swift
+++ b/Presentation/DesignSystem/Sources/ViewModifiers/AlertModifier.swift
@@ -1,0 +1,36 @@
+//
+//  AlertModifier.swift
+//  DesignSystem
+//
+//  Created by summercat on 1/30/25.
+//
+
+import SwiftUI
+
+public struct AlertModifier: ViewModifier {
+  @Binding var isPresented: Bool
+  
+  let alert: AlertView
+  
+  public func body(content: Content) -> some View {
+    content
+      .fullScreenCover(isPresented: $isPresented) {
+        ZStack {
+          Dimmer()
+          alert
+        }
+      }
+      .transaction { transaction in
+        transaction.disablesAnimations = true
+      }
+  }
+}
+
+public extension View {
+  func pcAlert(
+    isPresented: Binding<Bool>,
+    alert: @escaping () -> AlertView
+  ) -> some View {
+    return modifier(AlertModifier(isPresented: isPresented, alert: alert()))
+  }
+}

--- a/Presentation/Feature/MatchingDetail/Sources/Common/MatchDetailPhotoView.swift
+++ b/Presentation/Feature/MatchingDetail/Sources/Common/MatchDetailPhotoView.swift
@@ -1,0 +1,60 @@
+//
+//  MatchDetailPhotoView.swift
+//  MatchingDetail
+//
+//  Created by summercat on 1/30/25.
+//
+
+import DesignSystem
+import SwiftUI
+
+struct MatchDetailPhotoView: View {
+  private let uri: String
+  
+  init(uri: String) {
+    self.uri = uri
+  }
+  
+  var body: some View {
+    ZStack {
+      Dimmer()
+      content
+    }
+  }
+  
+  private var content: some View {
+    VStack(alignment: .center) {
+      NavigationBar(
+        title: "",
+        titleColor: .grayscaleWhite,
+        rightIcon: DesignSystemAsset.Icons.close32.swiftUIImage
+      ) {
+        
+      }
+      
+      Spacer()
+      
+      AsyncImage(url: URL(string: uri)) { image in
+        image.image?
+          .resizable()
+          .scaledToFill()
+      }
+      .frame(width: 180, height: 180)
+      .clipShape(Circle())
+      
+      Spacer()
+      
+      RoundedButton(
+        type: .solid,
+        buttonText: "매칭 수락하기",
+        rounding: true
+      ) {
+        
+      }
+    }
+  }
+}
+
+#Preview {
+  MatchDetailPhotoView(uri: "https://www.thesprucepets.com/thmb/AyzHgPQM_X8OKhXEd8XTVIa-UT0=/750x0/filters:no_upscale():max_bytes(150000):strip_icc():format(webp)/GettyImages-145577979-d97e955b5d8043fd96747447451f78b7.jpg")
+}


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-199](https://yapp25app3.atlassian.net/browse/PC-199)

## 👷🏼‍♂️ 변경 사항
- 매칭 상세 - 프로필 사진 화면 구현
- 서우님이 만들어주신 `AlertView`를 사용하기 위한 `pcAlert` modifier 구현
- `RoundedButton` 컴포넌트에서 너비값을 받을 수 있도록 수정
 
## 💬 참고 사항
- 

## 📸 스크린샷(Optional)
| 매칭 상세 - 사진 |
| :--: |
| ![image](https://github.com/user-attachments/assets/2d6aad91-f661-4416-b229-7ddc0a71927f) |

[PC-199]: https://yapp25app3.atlassian.net/browse/PC-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ