### PR TITLE
Feat: 회원탈퇴 화면 구현

### DIFF
--- a/Presentation/Coordinator/Project.swift
+++ b/Presentation/Coordinator/Project.swift
@@ -19,5 +19,6 @@ let project = Project.dynamicFramework(
     .presentation(target: .MatchingDetail),
     .presentation(target: .SignUp),
     .presentation(target: .EditValuePick),
+    .presentation(target: .Withdraw)
   ]
 )

--- a/Presentation/Coordinator/Sources/Coordinator.swift
+++ b/Presentation/Coordinator/Sources/Coordinator.swift
@@ -5,6 +5,7 @@
 //  Created by summercat on 1/30/25.
 //
 
+import Withdraw
 import EditValuePick
 import MatchingDetail
 import SignUp
@@ -99,6 +100,9 @@ public struct Coordinator {
         getMatchValuePicksUseCase: getMatchValuePicksUseCase,
         updateMatchValuePicksUseCase: updateMatchValuePicksUseCase
       )
+        
+    case .withDraw:
+        WithdrawViewFactory.createWithdrawView()
     }
   }
 }

--- a/Presentation/Coordinator/Sources/Coordinator.swift
+++ b/Presentation/Coordinator/Sources/Coordinator.swift
@@ -101,8 +101,10 @@ public struct Coordinator {
         updateMatchValuePicksUseCase: updateMatchValuePicksUseCase
       )
         
-    case .withDraw:
+    case .withdraw:
         WithdrawViewFactory.createWithdrawView()
+    case .withdrawConfirm:
+        WithdrawViewFactory.createWithdrawConfirm()
     }
   }
 }

--- a/Presentation/DesignSystem/Resources/Images.xcassets/img_leave.imageset/Contents.json
+++ b/Presentation/DesignSystem/Resources/Images.xcassets/img_leave.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "img_leave.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Presentation/DesignSystem/Sources/Color.swift
+++ b/Presentation/DesignSystem/Sources/Color.swift
@@ -27,3 +27,24 @@ public extension Color {
   static let alphaBlack40 = DesignSystemAsset.Colors.alphaBlack40.swiftUIColor
   static let systemError = DesignSystemAsset.Colors.systemError.swiftUIColor
 }
+
+public extension ShapeStyle where Self == Color {
+    static var grayscaleBlack: Color { DesignSystemAsset.Colors.grayscaleBlack.swiftUIColor }
+    static var grayscaleDark1: Color { DesignSystemAsset.Colors.grayscaleDark1.swiftUIColor }
+    static var grayscaleDark2: Color { DesignSystemAsset.Colors.grayscaleDark2.swiftUIColor }
+    static var grayscaleDark3: Color { DesignSystemAsset.Colors.grayscaleDark3.swiftUIColor }
+    static var grayscaleLight1: Color { DesignSystemAsset.Colors.grayscaleLight1.swiftUIColor }
+    static var grayscaleLight2: Color { DesignSystemAsset.Colors.grayscaleLight2.swiftUIColor }
+    static var grayscaleLight3: Color { DesignSystemAsset.Colors.grayscaleLight3.swiftUIColor }
+    static var grayscaleWhite: Color { DesignSystemAsset.Colors.grayscaleWhite.swiftUIColor }
+    static var primaryDefault: Color { DesignSystemAsset.Colors.primaryDefault.swiftUIColor }
+    static var primaryLight: Color { DesignSystemAsset.Colors.primaryLight.swiftUIColor }
+    static var primaryMiddle: Color { DesignSystemAsset.Colors.primaryMiddle.swiftUIColor }
+    static var subDefault: Color { DesignSystemAsset.Colors.subDefault.swiftUIColor }
+    static var subLight: Color { DesignSystemAsset.Colors.subLight.swiftUIColor }
+    static var subMiddle: Color { DesignSystemAsset.Colors.subMiddle.swiftUIColor }
+    static var alphaWhite10: Color { DesignSystemAsset.Colors.alphaWhite10.swiftUIColor }
+    static var alphaWhite60: Color { DesignSystemAsset.Colors.alphaWhite60.swiftUIColor }
+    static var alphaBlack40: Color { DesignSystemAsset.Colors.alphaBlack40.swiftUIColor }
+    static var systemError: Color { DesignSystemAsset.Colors.systemError.swiftUIColor }
+}

--- a/Presentation/DesignSystem/Sources/PCRadio.swift
+++ b/Presentation/DesignSystem/Sources/PCRadio.swift
@@ -1,0 +1,46 @@
+//
+//  PCRadio.swift
+//  DesignSystem
+//
+//  Created by 김도형 on 2/13/25.
+//
+
+import SwiftUI
+
+public struct PCRadio: View {
+    @Binding
+    private var isSelected: Bool
+    
+    public init(isSelected: Binding<Bool>) {
+        self._isSelected = isSelected
+    }
+    
+    public var body: some View {
+        Button(action: { isSelected.toggle() }) {
+            label
+        }
+        .frame(width: 20, height: 20)
+    }
+    
+    @ViewBuilder
+    private var label: some View {
+        Circle()
+            .fill(isSelected ? .primaryDefault : .clear)
+            .padding(4)
+            .background {
+                Circle()
+                    .stroke(
+                        isSelected ? .primaryDefault : .grayscaleLight1,
+                        lineWidth: 1
+                    )
+            }
+    }
+}
+
+@available(iOS 18.0, *)
+#Preview {
+    @Previewable
+    @State var isSelected = false
+    
+    PCRadio(isSelected: $isSelected)
+}

--- a/Presentation/Feature/Withdraw/Project.swift
+++ b/Presentation/Feature/Withdraw/Project.swift
@@ -1,0 +1,16 @@
+//
+// Project.swift
+// Withdraw
+//
+// Created by 김도형 on 2025/02/13.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.staticLibrary(
+  name: Modules.Presentation.Withdraw.rawValue,
+  dependencies: [
+    .presentation(target: .DesignSystem),
+  ]
+)

--- a/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmView.swift
@@ -17,7 +17,7 @@ struct WithdrawConfirmView: View {
   var body: some View {
     VStack(spacing: 0) {
       NavigationBar(
-        title: "탈퇴할래요",
+        title: "탈퇴하기",
         leftButtonTap: { router.pop() }
       )
       
@@ -40,7 +40,7 @@ struct WithdrawConfirmView: View {
       
       RoundedButton(
         type: .solid,
-        buttonText: "탈퇴하기",
+        buttonText: "탈퇴할래요",
         width: .maxWidth,
         action: { }
       )

--- a/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmView.swift
@@ -1,0 +1,70 @@
+//
+//  WithdrawConfirmView.swift
+//  Withdraw
+//
+//  Created by 김도형 on 2/13/25.
+//
+
+import SwiftUI
+import DesignSystem
+import PCFoundationExtension
+import Router
+
+struct WithdrawConfirmView: View {
+  @Environment(Router.self)
+  private var router: Router
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      NavigationBar(
+        title: "탈퇴하기",
+        leftButtonTap: { router.pop() }
+      )
+      
+      Rectangle()
+        .foregroundStyle(Color.grayscaleLight2)
+        .frame(height: 1)
+        .padding(.horizontal, 0)
+      
+      title
+        .padding(.top, 20)
+        .padding(.horizontal, 20)
+      
+      DesignSystemAsset.Images.imgLeave.swiftUIImage
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .frame(width: 300, height: 300)
+        .padding(.top, 60)
+      
+      Spacer()
+      
+      RoundedButton(
+        type: .solid,
+        buttonText: "탈퇴하기",
+        width: .maxWidth,
+        action: { }
+      )
+      .padding(.horizontal, 20)
+      .padding(.vertical, 12)
+    }
+    .toolbar(.hidden)
+  }
+}
+
+private extension WithdrawConfirmView {
+  var title: some View {
+    HStack {
+      VStack(alignment: .leading, spacing: 12) {
+        Text("정말 탈퇴하시겠어요?")
+          .pretendard(.heading_L_SB)
+          .foregroundStyle(.grayscaleBlack)
+        
+        Text("탈퇴하면 계정과 관련된 모든 정보가 삭제되며\n복구할 수 없습니다. 탈퇴하시겠습니까?")
+          .pretendard(.body_S_M)
+          .foregroundStyle(.grayscaleDark3)
+      }
+      
+      Spacer()
+    }
+  }
+}

--- a/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawConfirm/WithdrawConfirmView.swift
@@ -17,7 +17,7 @@ struct WithdrawConfirmView: View {
   var body: some View {
     VStack(spacing: 0) {
       NavigationBar(
-        title: "탈퇴하기",
+        title: "탈퇴할래요",
         leftButtonTap: { router.pop() }
       )
       

--- a/Presentation/Feature/Withdraw/Sources/WithdrawType.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawType.swift
@@ -1,0 +1,16 @@
+//
+//  WithdrawType.swift
+//  Withdraw
+//
+//  Created by 김도형 on 2/13/25.
+//
+
+import Foundation
+
+enum WithdrawType: String, CaseIterable {
+    case 애인이_생겼어요 = "애인이 생겼어요"
+    case 잠깐_쉬고_싶어요 = "잠깐 쉬고 싶어요"
+    case 매칭이_안_이루어져요 = "매칭이 안 이루어져요"
+    case 어플_사용성이_별로예요 = "어플 사용성이 별로예요"
+    case 기타 = "기타"
+}

--- a/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
@@ -18,9 +18,20 @@ struct WithdrawView: View {
   
   var body: some View {
     VStack(spacing: 0) {
+      NavigationBar(
+        title: "탈퇴하기",
+        leftButtonTap: { }
+      )
+      
+      Rectangle()
+        .foregroundStyle(Color.grayscaleLight2)
+        .frame(height: 1)
+        .padding(.horizontal, 0)
+      
       ScrollView {
         scrollContent
           .padding(.horizontal, 20)
+          .padding(.top, 20)
       }
       
       Spacer()

--- a/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
@@ -1,0 +1,19 @@
+//
+// WithdrawView.swift
+// Withdraw
+//
+// Created by 김도형 on 2025/02/13.
+//
+
+import SwiftUI
+import DesignSystem
+
+struct WithdrawView: View {
+  @State var viewModel: WithdrawViewModel
+
+  var body: some View {
+      VStack(spacing: 40) {
+      }
+  }
+}
+

--- a/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
@@ -43,7 +43,7 @@ struct WithdrawView: View {
             .padding(.horizontal, 20)
             .padding(.top, 20)
             .padding(.bottom, focusState ? 100 : 0)
-            .onChange(of: focusState) { oldValue, newValue in
+            .onChange(of: focusState) { _, newValue in
               guard newValue else { return }
               Task {
                 try? await Task.sleep(for: .milliseconds(50))
@@ -104,7 +104,7 @@ private extension WithdrawView {
   
   func radioListCell(type: WithdrawType) -> some View {
     HStack(spacing: 12) {
-      PCRadio(isSelected: Binding<Bool>(
+      PCRadio(isSelected: Binding(
         get: { viewModel.currentWithdraw == type },
         set: { viewModel.handleAction(.bindingWithdraw($0 ? type : nil)) }
       ))

--- a/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
@@ -7,8 +7,12 @@
 
 import SwiftUI
 import DesignSystem
+import Router
 
 struct WithdrawView: View {
+  @Environment(Router.self)
+  private var router: Router
+  
   @State var viewModel: WithdrawViewModel
   
   @FocusState
@@ -25,7 +29,7 @@ struct WithdrawView: View {
     VStack(spacing: 0) {
       NavigationBar(
         title: "탈퇴하기",
-        leftButtonTap: { }
+        leftButtonTap: { router.pop() }
       )
       
       Rectangle()
@@ -55,12 +59,13 @@ struct WithdrawView: View {
         type: viewModel.isValid ? .solid : .disabled,
         buttonText: "다음",
         width: .maxWidth,
-        action: { }
+        action: { router.push(to: .withdrawConfirm) }
       )
       .animation(.easeInOut, value: viewModel.isValid)
       .padding(.horizontal, 20)
       .padding(.vertical, 12)
     }
+    .toolbar(.hidden)
   }
 }
 

--- a/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
@@ -10,10 +10,131 @@ import DesignSystem
 
 struct WithdrawView: View {
   @State var viewModel: WithdrawViewModel
-
+  
+  init(viewModel: WithdrawViewModel) {
+    self.viewModel = viewModel
+    UITextView.appearance().textContainerInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+  }
+  
   var body: some View {
-      VStack(spacing: 40) {
+    VStack(spacing: 0) {
+      ScrollView {
+        scrollContent
+          .padding(.horizontal, 20)
       }
+      
+      Spacer()
+      
+      RoundedButton(
+        type: viewModel.isValid ? .solid : .disabled,
+        buttonText: "다음",
+        width: .maxWidth,
+        action: { }
+      )
+      .animation(.easeInOut, value: viewModel.isValid)
+      .padding(.horizontal, 20)
+      .padding(.vertical, 12)
+    }
   }
 }
 
+private extension WithdrawView {
+  var scrollContent: some View {
+    VStack(alignment: .leading, spacing: 40) {
+      title
+      
+      radioList
+    }
+  }
+  
+  var title: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("지금 탈퇴하면\n새로운 인연을 만날 수 없어요")
+        .pretendard(.heading_L_SB)
+        .foregroundStyle(.grayscaleBlack)
+      
+      Text("탈퇴하는 이유를 알려주세요.\n반영하여 더 나은 사용자 경험을 제공하겠습니다.")
+        .pretendard(.body_S_M)
+        .foregroundStyle(.grayscaleDark3)
+    }
+  }
+  
+  var radioList: some View {
+    VStack(spacing: 0) {
+      ForEach(WithdrawType.allCases, id: \.self) { type in
+        radioListCell(type: type)
+      }
+      
+      if viewModel.currentWithdraw == .기타 {
+        textEditor
+      }
+    }
+  }
+  
+  func radioListCell(type: WithdrawType) -> some View {
+    HStack(spacing: 12) {
+      PCRadio(isSelected: Binding<Bool>(
+        get: { viewModel.currentWithdraw == type },
+        set: { viewModel.handleAction(.bindingWithdraw($0 ? type : nil)) }
+      ))
+      .padding(.leading, 14)
+      .animation(.easeInOut, value: viewModel.currentWithdraw)
+      
+      Text(type.rawValue)
+        .foregroundStyle(.grayscaleBlack)
+        .pretendard(.body_M_R)
+        .padding(.vertical, 14)
+      
+      Spacer(minLength: 14)
+    }
+  }
+  
+  @ViewBuilder
+  var textEditor: some View {
+    VStack(spacing: 16) {
+      TextEditor(text: Binding(
+        get: { viewModel.editorText ?? "" },
+        set: { viewModel.handleAction(.bindingEditorText($0)) }
+      ))
+      .autocorrectionDisabled()
+      .textInputAutocapitalization(.never)
+      .scrollContentBackground(.hidden)
+      .foregroundStyle(.grayscaleBlack)
+      .background(alignment: .topLeading) {
+        if viewModel.editorText?.isEmpty ?? true {
+          Text("자유롭게 작성해주세요")
+            .foregroundStyle(.grayscaleDark3)
+            .padding(.leading, 4)
+        }
+      }
+      .pretendard(.body_M_M)
+      
+      textCount
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 14)
+    .background(.grayscaleLight3)
+    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+    .clipped()
+    .frame(minHeight: 160)
+  }
+  
+  var textCount: some View {
+    let count = viewModel.editorText?.count ?? 0
+    var text = AttributedString("\(count)")
+    text.setAttributes(AttributeContainer([
+      .foregroundColor: UIColor(.primaryDefault)
+    ]))
+    
+    return HStack {
+      Spacer()
+      
+      Text(text + "/100")
+        .pretendard(.body_S_M)
+        .foregroundStyle(.grayscaleDark3)
+        .contentTransition(.numericText())
+    }
+    .opacity(count == 0 ? 0 : 1)
+    .animation(.default, value: count)
+  }
+}

--- a/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawView.swift
@@ -66,6 +66,9 @@ struct WithdrawView: View {
       .padding(.vertical, 12)
     }
     .toolbar(.hidden)
+    .onTapGesture {
+        focusState = false
+    }
   }
 }
 

--- a/Presentation/Feature/Withdraw/Sources/WithdrawViewFactory.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawViewFactory.swift
@@ -11,4 +11,8 @@ public struct WithdrawViewFactory {
     public static func createWithdrawView() -> some View {
         WithdrawView(viewModel: WithdrawViewModel())
     }
+    
+    public static func createWithdrawConfirm() -> some View {
+        WithdrawConfirmView()
+    }
 }

--- a/Presentation/Feature/Withdraw/Sources/WithdrawViewFactory.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawViewFactory.swift
@@ -1,0 +1,14 @@
+//
+//  WithdrawViewFactory.swift
+//  Withdraw
+//
+//  Created by 김도형 on 2/13/25.
+//
+
+import SwiftUI
+
+public struct WithdrawViewFactory {
+    public static func createWithdrawView() -> some View {
+        WithdrawView(viewModel: WithdrawViewModel())
+    }
+}

--- a/Presentation/Feature/Withdraw/Sources/WithdrawViewModel.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawViewModel.swift
@@ -9,5 +9,28 @@ import Foundation
 
 @Observable
 final class WithdrawViewModel {
-  enum Action { }
+  enum Action {
+    case bindingWithdraw(WithdrawType?)
+    case bindingEditorText(String?)
+  }
+  
+  private(set) var currentWithdraw: WithdrawType?
+  private(set) var editorText: String?
+  var isValid: Bool {
+    guard currentWithdraw != nil else { return false }
+    guard currentWithdraw != .기타 else {
+      return editorText?.count ?? 0 > 0
+    }
+    return true
+  }
+  
+  func handleAction(_ action: Action) {
+    switch action {
+    case .bindingWithdraw(let withdraw):
+      currentWithdraw = withdraw
+    case .bindingEditorText(let text):
+      guard (text?.count ?? 0) <= 100 else { return }
+      editorText = text
+    }
+  }
 }

--- a/Presentation/Feature/Withdraw/Sources/WithdrawViewModel.swift
+++ b/Presentation/Feature/Withdraw/Sources/WithdrawViewModel.swift
@@ -1,0 +1,13 @@
+//
+// WithdrawViewModel.swift
+// Withdraw
+//
+// Created by 김도형 on 2025/02/13.
+//
+
+import Foundation
+
+@Observable
+final class WithdrawViewModel {
+  enum Action { }
+}

--- a/Presentation/Router/Sources/Route.swift
+++ b/Presentation/Router/Sources/Route.swift
@@ -15,5 +15,6 @@ public enum Route: Hashable {
   case signUp
   case createProfile
   case editValuePick
-  case withDraw
+  case withdraw
+  case withdrawConfirm
 }

--- a/Presentation/Router/Sources/Route.swift
+++ b/Presentation/Router/Sources/Route.swift
@@ -15,4 +15,5 @@ public enum Route: Hashable {
   case signUp
   case createProfile
   case editValuePick
+  case withDraw
 }

--- a/Tuist/ProjectDescriptionHelpers/Modules.swift
+++ b/Tuist/ProjectDescriptionHelpers/Modules.swift
@@ -83,6 +83,7 @@ public extension Modules {
     case MatchingMain
     case MatchingDetail
     case EditValuePick
+    case Withdraw
     
     var path: String {
       switch self {


### PR DESCRIPTION
## 🏷️ 티켓 번호

## 👷🏼‍♂️ 변경 사항
- 회원 탈퇴하기 화면만 구성하였습니다
- `foregroundStyle` 모디파이어 쓰기 편하도록 `extension` 하나 추가했습니다
- `PCRadio` 버튼 제작했습니다.
 
## 💬 참고 사항
- 티켓 번호 몰라서 그냥 공란으로 남겼습니다..ㅎㅎ
- 코드 컨벤션 잘 모르겠어서 있는 코드 보고 최대한 맞춰보긴 했는데.. 수정할거 있으면 편하게 말씀주세요
- `xcconfig`가 없기도 하고, 제 xcode 버전이 아직 16.0이라 로컬에서 `Tuist` 설정 좀 건들었는데 혹시나 변경사항이 푸시 되어있다면 말씀해주세요
- 아직 탈퇴하기 `API` 안나왔다고 하셔서 그냥 깡통 화면입니다
- 아직 비지니스 로직이랄게 없어서 `Factory`에 깡통으로 등록했습니다. 참고해주세여~
```Swift
public struct WithdrawViewFactory {
    public static func createWithdrawView() -> some View {
        WithdrawView(viewModel: WithdrawViewModel())
    }
    
    public static func createWithdrawConfirm() -> some View {
        WithdrawConfirmView()
    }
}
```
- 원래 `tapGesture` 모디파이어로 키보드 내리기 구현이 좀 부자연스러웠던걸로 기억하는데.. 지금은 별 문제 없이 잘 되는거 같네요.. 혹시나 문제 있으면 말씀해주세요.

## 📸 스크린샷(Optional)
| 회원 탈퇴 |
| :--: |
| ![Simulator Screen Recording - iPhone 16 Pro - 2025-02-13 at 23 57 20](https://github.com/user-attachments/assets/99f49f3a-d685-43f2-958f-6f1589304878)  |