### PR TITLE
[PC-675] Feat: role이 USER가 아닌 사용자는 프로필 탭에 진입할 수 없다

### DIFF
--- a/Data/LocalStorage/Sources/UserDefaults/PCUserDefaultsService.swift
+++ b/Data/LocalStorage/Sources/UserDefaults/PCUserDefaultsService.swift
@@ -5,6 +5,7 @@
 //  Created by summercat on 2/13/25.
 //
 
+import Entities
 import Foundation
 
 public final class PCUserDefaultsService {
@@ -39,12 +40,27 @@ public final class PCUserDefaultsService {
       _ = PCUserDefaults.setObjectFor(key: .socialLoginType, object: newValue)
     }
   }
+  
+  var userRole: UserRole {
+    get {
+      if let value = PCUserDefaults.objectFor(key: .userRole) as? String {
+        return UserRole(value)
+      } else {
+        return .NONE
+      }
+    }
+    set {
+      _ = PCUserDefaults.setObjectFor(key: .userRole, object: newValue.rawValue)
+    }
+  }
 }
 
 public extension PCUserDefaultsService {
   // 로그아웃 시 UserDefaults 초기화 메서드
   func initialize() {
     didSeeOnboarding = false
+    socialLoginType = ""
+    userRole = .NONE
   }
   
   func getDidSeeOnboarding() -> Bool {
@@ -76,5 +92,13 @@ public extension PCUserDefaultsService {
   func resetFirstLaunch() {
     isFirstLaunch = true
     didSeeOnboarding = false
+  }
+  
+  func getUserRole() -> UserRole {
+    userRole
+  }
+  
+  func setUserRole(_ userRole: UserRole) {
+    self.userRole = userRole
   }
 }

--- a/Data/LocalStorage/Sources/UserDefaults/UserDefaultsKeys.swift
+++ b/Data/LocalStorage/Sources/UserDefaults/UserDefaultsKeys.swift
@@ -9,4 +9,5 @@ public enum UserDefaultsKeys: String {
   case isFirstLaunch
   case didSeeOnboarding
   case socialLoginType
+  case userRole
 }

--- a/Presentation/Feature/Home/Project.swift
+++ b/Presentation/Feature/Home/Project.swift
@@ -11,6 +11,7 @@ import ProjectDescriptionHelpers
 let project = Project.staticLibrary(
   name: Modules.Presentation.Home.rawValue,
   dependencies: [
+    .data(target: .LocalStorage),
     .presentation(target: .DesignSystem),
     .presentation(target: .Router),
     .presentation(target: .Profile),

--- a/Presentation/Feature/Home/Sources/HomeView.swift
+++ b/Presentation/Feature/Home/Sources/HomeView.swift
@@ -43,6 +43,7 @@ struct HomeView: View {
       content
       TabBarView(viewModel: viewModel.tabbarViewModel)
     }
+    .toolbar(.hidden)
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
   

--- a/Presentation/Feature/Home/Sources/HomeViewModel.swift
+++ b/Presentation/Feature/Home/Sources/HomeViewModel.swift
@@ -6,8 +6,8 @@
 //
 
 import DesignSystem
+import LocalStorage
 import Observation
-import SwiftUI
 import UseCases
 
 @Observable

--- a/Presentation/Feature/Home/Sources/TabBarButton.swift
+++ b/Presentation/Feature/Home/Sources/TabBarButton.swift
@@ -1,0 +1,36 @@
+//
+//  TabBarButton.swift
+//  Home
+//
+//  Created by summercat on 3/6/25.
+//
+
+import SwiftUI
+
+// MARK: - 탭바 버튼
+struct TabBarButton: View {
+  init(
+    tabBarImage: Image,
+    tabBarTitle: String,
+    isSelected: Bool
+  ) {
+    self.tabBarImage = tabBarImage
+    self.tabBarTitle = tabBarTitle
+    self.isSelected = isSelected
+  }
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      tabBarImage
+        .renderingMode(.template)
+      Text(tabBarTitle)
+        .pretendard(.caption_M_M)
+    }
+    .foregroundColor(isSelected ? .primaryDefault : .grayscaleDark3)
+  }
+  
+  private let tabBarImage: Image
+  private let tabBarTitle: String
+  private let isSelected: Bool
+}
+

--- a/Presentation/Feature/Home/Sources/TabBarView.swift
+++ b/Presentation/Feature/Home/Sources/TabBarView.swift
@@ -5,20 +5,20 @@
 //  Created by eunseou on 12/28/24.
 //
 
-import Observation
+import DesignSystem
 import SwiftUI
 
 // MARK: - 탭바 뷰
-public struct TabBarView: View {
+struct TabBarView: View {
   @State private var viewModel: TabBarViewModel
   
-  public init(
+  init(
     viewModel: TabBarViewModel
   ) {
     self.viewModel = viewModel
   }
   
-  public var body: some View {
+  var body: some View {
     VStack {
       Spacer()
       HStack {
@@ -28,17 +28,18 @@ public struct TabBarView: View {
           viewModel.selectedTab = .profile
         } label: {
           TabBarButton(
-            tabBarImage: .profile32,
+            tabBarImage: DesignSystemAsset.Icons.profile32.swiftUIImage,
             tabBarTitle: "프로필",
             isSelected: viewModel.selectedTab == .profile
           )
+          .disabled(viewModel.isProfileTabDisabled)
         }
         Spacer()
         Button {
           print("홈")
           viewModel.selectedTab = .home
         } label: {
-          Image(.btnMatch)
+          DesignSystemAsset.Icons.btnMatch.swiftUIImage
             .offset(y: -12)
         }
         Spacer()
@@ -47,7 +48,7 @@ public struct TabBarView: View {
           viewModel.selectedTab = .settings
         } label: {
           TabBarButton(
-            tabBarImage: .setting32,
+            tabBarImage: DesignSystemAsset.Icons.setting32.swiftUIImage,
             tabBarTitle: "설정",
             isSelected: viewModel.selectedTab == .settings
           )
@@ -59,48 +60,6 @@ public struct TabBarView: View {
     }
   }
 }
-
-// MARK: - 탭바 뷰모델 (임시)
-@Observable
-public class TabBarViewModel {
-  public var selectedTab: Tab = .home
-  
-  public init() { }
-  
-  public enum Tab {
-    case profile
-    case home
-    case settings
-  }
-}
-
-// MARK: - 탭바 버튼
-public struct TabBarButton: View {
-  public init(
-    tabBarImage: ImageResource,
-    tabBarTitle: String,
-    isSelected: Bool
-  ) {
-    self.tabBarImage = tabBarImage
-    self.tabBarTitle = tabBarTitle
-    self.isSelected = isSelected
-  }
-  
-  public var body: some View {
-    VStack(spacing: 0) {
-      Image(tabBarImage)
-        .renderingMode(.template)
-      Text(tabBarTitle)
-        .pretendard(.caption_M_M)
-    }
-    .foregroundColor(isSelected ? .primaryDefault : .grayscaleDark3)
-  }
-  
-  private let tabBarImage: ImageResource
-  private let tabBarTitle: String
-  private let isSelected: Bool
-}
-
 
 // MARK: - Preivew
 #Preview {

--- a/Presentation/Feature/Home/Sources/TabBarViewModel.swift
+++ b/Presentation/Feature/Home/Sources/TabBarViewModel.swift
@@ -1,0 +1,30 @@
+//
+//  TabBarViewModel.swift
+//  Home
+//
+//  Created by summercat on 3/6/25.
+//
+
+import LocalStorage
+import Observation
+
+@Observable
+class TabBarViewModel {
+  var selectedTab: Tab = .home
+  var isProfileTabDisabled: Bool
+  
+  init() {
+    let userRole = PCUserDefaultsService.shared.getUserRole()
+    if userRole == .USER {
+      isProfileTabDisabled = false
+    } else {
+      isProfileTabDisabled = true
+    }
+  }
+  
+  enum Tab {
+    case profile
+    case home
+    case settings
+  }
+}

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkCardViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/ValueTalk/ValueTalkCardViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  ViewTalkCardViewModel.swift
+//  ValueTalkCardViewModel.swift
 //  SignUp
 //
 //  Created by summercat on 2/9/25.

--- a/Presentation/Feature/Splash/Sources/SplashViewModel.swift
+++ b/Presentation/Feature/Splash/Sources/SplashViewModel.swift
@@ -122,6 +122,7 @@ final class SplashViewModel {
     // 사용자 role에 따라 화면 분기 처리
     let userInfo = try await getUserInfoUseCase.execute()
     let userRole = userInfo.role
+    PCUserDefaultsService.shared.setUserRole(userRole)
     
     switch userRole {
     case .NONE:


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-674](https://yapp25app3.atlassian.net/browse/PC-674)
[PC-681](https://yapp25app3.atlassian.net/browse/PC-681)

## 👷🏼‍♂️ 변경 사항
- role이 USER가 아닌 사용자는 홈 화면의 탭에서 Profile에 진입할 수 없도록 수정
- `TabBarView`를 `Home` 모듈로 이동
  - 홈 화면에 종속적인 로직을 처리하는 뷰여서 이동함
- 홈 화면에서 기본 내비게이션바 제거
 
## 💬 참고 사항
- 

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-674]: https://yapp25app3.atlassian.net/browse/PC-674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PC-681]: https://yapp25app3.atlassian.net/browse/PC-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ