### PR TITLE
[PC-705] Fix: 프로필 생성 시 가치관Talk 답변이 비어있는 문제 수정

### DIFF
--- a/Presentation/DesignSystem/Sources/NavigationBar/NavigationBar.swift
+++ b/Presentation/DesignSystem/Sources/NavigationBar/NavigationBar.swift
@@ -113,12 +113,14 @@ public struct NavigationBar: View {
   
   public init(
     title: String,
-    titleColor: Color = .grayscaleBlack
+    titleColor: Color = .grayscaleBlack,
+    backgroundColor: Color? = .clear
   ) {
     self.init(
       type: .titleOnly,
       title: title,
-      titleColor: titleColor
+      titleColor: titleColor,
+      backgroundColor: backgroundColor
     )
   }
   
@@ -236,6 +238,7 @@ public struct NavigationBar: View {
         label: "label",
         backgroundColor: .white
       )
+      NavigationBar(title: "프로필 생성하기", backgroundColor: .grayscaleWhite)
     }
   }
 }

--- a/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideView.swift
+++ b/Presentation/Feature/SignUp/Sources/AvoidContactsGuide/AvoidContactsGuideView.swift
@@ -80,7 +80,7 @@ struct AvoidContactsGuideView: View {
   
   private var title: some View {
     VStack(alignment: .leading, spacing: 12) {
-      Text("아는사람")
+      Text("아는 사람")
         .foregroundStyle(Color.primaryDefault) +
       Text("에게는\n프로필이 노출되지 않아요")
       

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/CreateProfileContainerView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/CreateProfileContainerView.swift
@@ -40,7 +40,8 @@ struct CreateProfileContainerView: View {
     VStack(spacing: 0) {
       switch viewModel.currentStep {
       case .basicInfo:
-        NavigationBar(title: "프로필 생성하기")
+        Spacer()
+          .frame(height: 60)
       case .valueTalk:
         NavigationBar(
           title: "",

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/CreateProfileContainerViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/CreateProfileContainerViewModel.swift
@@ -122,7 +122,6 @@ final class CreateProfileContainerViewModel {
   }
     
   private func createProfile() {
-    profileCreator.updateValueTalks(valueTalks)
     profileCreator.updateValuePicks(valuePicks)
     profile = profileCreator.createProfile()
   }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-705](https://yapp25app3.atlassian.net/browse/PC-705)

## 👷🏼‍♂️ 변경 사항
- 프로필 생성 버튼을 눌렀을 때 서버로부터 받은 빈 가치관Talk으로 가치관Talk을 다시 업데이트 하고 있어서 발생
- 이외 디자인가이드와 맞지 않는 UI 수정
 
## 💬 참고 사항
- 

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |