### PR TITLE
[PC-745] Fix: 프로필 생성, 수정 화면 텍스트필드 정규식 적용

### DIFF
--- a/Data/DTO/Sources/Profile/ProfileBasicResponseDTO.swift
+++ b/Data/DTO/Sources/Profile/ProfileBasicResponseDTO.swift
@@ -30,7 +30,7 @@ public extension ProfileBasicResponseDTO {
       nickname: nickname,
       description: description,
       age: age,
-      birthdate: birthdate.extractYear(),
+      birthdate: birthdate,
       height: height,
       weight: weight,
       job: job,

--- a/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileView.swift
@@ -413,7 +413,8 @@ struct EditProfileView: View {
           text: Binding(
             get: { contact.value },
             set: { newValue in
-              if let index = viewModel.contacts.firstIndex(where: { $0.id == contact.id }) {
+              if viewModel.isAllowedInput(newValue),
+                 let index = viewModel.contacts.firstIndex(where: { $0.id == contact.id }) {
                 viewModel.contacts[index].value = newValue
               }
             }
@@ -433,6 +434,8 @@ struct EditProfileView: View {
             viewModel.isContactTypeChangeSheetPresented = true
           }
         )
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled(true)
         .frame(minHeight: 72)
         .id("contact_\(contact.id)_scroll")
       }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -138,6 +138,8 @@ final class EditProfileViewModel {
   var heightInfoText: String {
     if height.isEmpty && didTapnextButton {
       return "필수 항목을 입력해 주세요."
+    } else if !height.isEmpty && ( height.count >= 4 || height.count < 2 ) {
+      return "숫자가 정확한 지 확인해 주세요."
     } else {
       return ""
     }
@@ -145,6 +147,8 @@ final class EditProfileViewModel {
   var weightInfoText: String {
     if weight.isEmpty && didTapnextButton {
       return "필수 항목을 입력해 주세요."
+    } else if !weight.isEmpty && ( weight.count >= 4 || weight.count < 2 ) {
+      return "숫자가 정확한 지 확인해 주세요."
     } else {
       return ""
     }

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -61,6 +61,12 @@ final class EditProfileViewModel {
     !description.isEmpty && description.count <= 20
   }
   var isValidBirthDate: Bool { isValidBirthDateFormat(birthDate) }
+  var isValidHeight: Bool {
+    (2...3).contains(height.count) && height.allSatisfy(\.isNumber)
+  }
+  var isVaildWeight: Bool {
+    (2...3).contains(weight.count) && weight.allSatisfy(\.isNumber)
+  }
   var isContactsValid: Bool {
     return contacts.allSatisfy { !$0.value.isEmpty }
   }
@@ -70,10 +76,10 @@ final class EditProfileViewModel {
     isValidBirthDate &&
     !nickname.isEmpty &&
     !description.isEmpty &&
-    !birthDate.isEmpty &&
+    isValidBirthDate &&
     !location.isEmpty &&
-    !height.isEmpty &&
-    !weight.isEmpty &&
+    isValidHeight &&
+    isVaildWeight &&
     !job.isEmpty &&
     isContactsValid
   }
@@ -138,7 +144,7 @@ final class EditProfileViewModel {
   var heightInfoText: String {
     if height.isEmpty && didTapnextButton {
       return "필수 항목을 입력해 주세요."
-    } else if !height.isEmpty && ( height.count >= 4 || height.count < 2 ) {
+    } else if !height.isEmpty && !((2...3).contains(height.count) && height.allSatisfy(\.isNumber)) {
       return "숫자가 정확한 지 확인해 주세요."
     } else {
       return ""
@@ -147,7 +153,7 @@ final class EditProfileViewModel {
   var weightInfoText: String {
     if weight.isEmpty && didTapnextButton {
       return "필수 항목을 입력해 주세요."
-    } else if !weight.isEmpty && ( weight.count >= 4 || weight.count < 2 ) {
+    } else if !weight.isEmpty && !((2...3).contains(weight.count) && weight.allSatisfy(\.isNumber)) {
       return "숫자가 정확한 지 확인해 주세요."
     } else {
       return ""

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -402,7 +402,7 @@ final class EditProfileViewModel {
       
       nickname = profile.nickname
       description = profile.description
-      birthDate = profile.birthdate
+      birthDate = profile.birthdate.toCompactDateString
       location = profile.location
       height = String(profile.height)
       weight = String(profile.weight)

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -314,6 +314,13 @@ final class EditProfileViewModel {
     return dateTest.evaluate(with: date) && date.count == 8
   }
   
+  func isAllowedInput(_ input: String) -> Bool {
+      let pattern = #"^[A-Za-z0-9\s[:punct:][:symbol:]]*$"#
+      guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+      let range = NSRange(location: 0, length: input.utf16.count)
+      return regex.firstMatch(in: input, options: [], range: range) != nil
+  }
+  
   func saveSelectedJob() {
     if isCustomJobSelected {
       self.job = customJobText.isEmpty ? "" : customJobText

--- a/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
+++ b/Presentation/Feature/EditProfile/Sources/EditProfileViewModel.swift
@@ -299,7 +299,7 @@ final class EditProfileViewModel {
   }
   
   private func isValidBirthDateFormat(_ date: String) -> Bool {
-    let dateRegex = "^[0-9]{8}$" // YYYYMMDD
+    let dateRegex = #"^(19|20)\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])$"# // YYYYMMDD
     let dateTest = NSPredicate(format: "SELF MATCHES %@", dateRegex)
     return dateTest.evaluate(with: date) && date.count == 8
   }

--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainView.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainView.swift
@@ -142,17 +142,19 @@ struct MatchingMainView: View {
       
       VStack {
         VStack(alignment: .center, spacing: 8) {
-          Text("진중한 만남")
-            .foregroundStyle(Color.primary) +
-          Text("을 이어가기 위해\n프로필을 살펴보고 있어요")
-            .foregroundStyle(Color.grayscaleBlack)
+          Group {
+            Text("진중한 만남")
+              .foregroundStyle(Color.primaryDefault) +
+            Text("을 이어가기 위해\n프로필을 살펴보고 있어요")
+              .foregroundStyle(Color.grayscaleBlack)
+          }
+          .pretendard(.heading_M_SB)
           Text("작성 후 24시간 이내에 심사가 진행됩니다.\n생성한 프로필을 검토하며 기다려 주세요.")
-            .pretendard(.heading_S_M)
+            .pretendard(.body_S_M)
             .foregroundStyle(Color.grayscaleDark3)
         }
         .padding(.top, 40)
         .padding(.bottom, 20)
-        .pretendard(.heading_M_SB)
         .multilineTextAlignment(.center)
         
         DesignSystemAsset.Images.imgScreening.swiftUIImage

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -418,6 +418,8 @@ struct CreateBasicInfoView: View {
             viewModel.isContactTypeChangeSheetPresented = true
           }
         )
+        .textInputAutocapitalization(.never)
+        .autocorrectionDisabled(true)
         .frame(minHeight: 72)
         .id("contact_\(contact.id)_scroll")
       }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoView.swift
@@ -398,7 +398,8 @@ struct CreateBasicInfoView: View {
           text: Binding(
             get: { contact.value },
             set: { newValue in
-              if let index = viewModel.contacts.firstIndex(where: { $0.id == contact.id }) {
+              if viewModel.isAllowedInput(newValue),
+                 let index = viewModel.contacts.firstIndex(where: { $0.id == contact.id }) {
                 viewModel.contacts[index].value = newValue
               }
             }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -299,6 +299,13 @@ final class CreateBasicInfoViewModel {
     return dateTest.evaluate(with: date) && date.count == 8
   }
   
+  func isAllowedInput(_ input: String) -> Bool {
+      let pattern = #"^[A-Za-z0-9\s[:punct:][:symbol:]]*$"#
+      guard let regex = try? NSRegularExpression(pattern: pattern) else { return false }
+      let range = NSRange(location: 0, length: input.utf16.count)
+      return regex.firstMatch(in: input, options: [], range: range) != nil
+  }
+  
   func saveSelectedJob() {
     if isCustomJobSelected {
       self.job = customJobText.isEmpty ? "" : customJobText

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -284,7 +284,7 @@ final class CreateBasicInfoViewModel {
   }
   
   private func isValidBirthDateFormat(_ date: String) -> Bool {
-    let dateRegex = "^[0-9]{8}$" // YYYYMMDD
+    let dateRegex = #"^(19|20)\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])$"# // YYYYMMDD
     let dateTest = NSPredicate(format: "SELF MATCHES %@", dateRegex)
     return dateTest.evaluate(with: date) && date.count == 8
   }

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -54,6 +54,12 @@ final class CreateBasicInfoViewModel {
     !description.isEmpty && description.count <= 20
   }
   var isValidBirthDate: Bool { isValidBirthDateFormat(birthDate) }
+  var isValidHeight: Bool {
+    (2...3).contains(height.count) && height.allSatisfy(\.isNumber)
+  }
+  var isVaildWeight: Bool {
+    (2...3).contains(weight.count) && weight.allSatisfy(\.isNumber)
+  }
   var isContactsValid: Bool {
     return contacts.allSatisfy { !$0.value.isEmpty }
   }
@@ -63,10 +69,10 @@ final class CreateBasicInfoViewModel {
     isValidBirthDate &&
     !nickname.isEmpty &&
     !description.isEmpty &&
-    !birthDate.isEmpty &&
+    isValidBirthDate &&
     !location.isEmpty &&
-    !height.isEmpty &&
-    !weight.isEmpty &&
+    isValidHeight &&
+    isVaildWeight &&
     !job.isEmpty &&
     isContactsValid
   }
@@ -120,7 +126,7 @@ final class CreateBasicInfoViewModel {
   var heightInfoText: String {
     if height.isEmpty && didTapnextButton {
       return "필수 항목을 입력해 주세요."
-    } else if !height.isEmpty && ( height.count >= 4 || height.count < 2 ) {
+    } else if !height.isEmpty && !((2...3).contains(height.count) && height.allSatisfy(\.isNumber)) {
       return "숫자가 정확한 지 확인해 주세요."
     } else {
       return ""
@@ -129,7 +135,7 @@ final class CreateBasicInfoViewModel {
   var weightInfoText: String {
     if weight.isEmpty && didTapnextButton {
       return "필수 항목을 입력해 주세요."
-    } else if !weight.isEmpty && ( weight.count >= 4 || weight.count < 2 ) {
+    } else if !weight.isEmpty && !((2...3).contains(weight.count) && weight.allSatisfy(\.isNumber)) {
       return "숫자가 정확한 지 확인해 주세요."
     } else {
       return ""

--- a/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
+++ b/Presentation/Feature/SignUp/Sources/CreateProfile/BasicInfo/CreateBasicInfoViewModel.swift
@@ -120,6 +120,8 @@ final class CreateBasicInfoViewModel {
   var heightInfoText: String {
     if height.isEmpty && didTapnextButton {
       return "필수 항목을 입력해 주세요."
+    } else if !height.isEmpty && ( height.count >= 4 || height.count < 2 ) {
+      return "숫자가 정확한 지 확인해 주세요."
     } else {
       return ""
     }
@@ -127,6 +129,8 @@ final class CreateBasicInfoViewModel {
   var weightInfoText: String {
     if weight.isEmpty && didTapnextButton {
       return "필수 항목을 입력해 주세요."
+    } else if !weight.isEmpty && ( weight.count >= 4 || weight.count < 2 ) {
+      return "숫자가 정확한 지 확인해 주세요."
     } else {
       return ""
     }

--- a/Utility/PCFoundationExtension/Sources/String+Extension.swift
+++ b/Utility/PCFoundationExtension/Sources/String+Extension.swift
@@ -17,6 +17,10 @@ public extension String {
     
     return lastTwoDigits
   }
+  
+  var toCompactDateString: String {
+    return self.replacingOccurrences(of: "-", with: "")
+  }
 }
 
 // MARK: - decodeJWT


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-745](https://yapp25app3.atlassian.net/browse/PC-745)

## 👷🏼‍♂️ 변경 사항
- ProfileBasicResponseDTO에서 birthdate를 받아올 때, extractYear을 중복으로 쓰여 DTO에서 제거했습니다.
- 프로필 생성, 수정 시 텍스트 필드 정규식 적용해 잘못된 값 입력 방지
  - 연락처 영어, 숫자, 특수문자만 입력되도록
  -  키,몸무게 2~3자 제한
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 | 화면 이름 |
| :--: | :--: |
| ![image](https://github.com/user-attachments/assets/4ee4df8e-b005-46b1-8959-eac7de74c508) | ![image](https://github.com/user-attachments/assets/de3dbeac-8f52-4cde-a54c-1453044e260b) |

[PC-745]: https://yapp25app3.atlassian.net/browse/PC-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ