### PR TITLE
[PC-780] Fix: 매칭 Nodata 상태 시 카드 상단 타이머 앞 텍스트 수정

### DIFF
--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainView.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainView.swift
@@ -51,10 +51,10 @@ struct MatchingMainView: View {
           if matchingMainViewModel.isShowMatchingPendingCard {
             matchingPendingCard
           } else if matchingMainViewModel.isShowMatchingNodataCard{
-            MatchingTimer(matchingTimerViewModel: matchingTimerViewModel)
+            MatchingTimer(matchingTimerViewModel: matchingTimerViewModel, prefixMessage: "소중한 인연이 시작되기까지")
             matchingNoDataCard
           } else if matchingMainViewModel.isShowMatchingMainBasicCard {
-            MatchingTimer(matchingTimerViewModel: matchingTimerViewModel)
+            MatchingTimer(matchingTimerViewModel: matchingTimerViewModel, prefixMessage: "소중한 인연이 사라지기까지")
             matchingBasicCard
           }
         }

--- a/Presentation/Feature/MatchingMain/Sources/MatchingTimer.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingTimer.swift
@@ -11,10 +11,11 @@ import DesignSystem
 // MARK: - 타이머
 struct MatchingTimer: View {
   @Bindable var matchingTimerViewModel: MatchingTimerViewModel
+  let prefixMessage: String
   
   var body: some View {
     HStack(spacing: 4) {
-      Text("소중한 인연이 사라지기까지")
+      Text(prefixMessage)
       Text(matchingTimerViewModel.state.timeString)
         .pretendard(.body_S_SB)
         .foregroundColor(.subDefault)
@@ -34,5 +35,5 @@ struct MatchingTimer: View {
 }
 
 #Preview {
-  MatchingTimer(matchingTimerViewModel: MatchingTimerViewModel())
+  MatchingTimer(matchingTimerViewModel: MatchingTimerViewModel(), prefixMessage: "소중한 인연이 사라지기까지")
 }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-780](https://yapp25app3.atlassian.net/browse/PC-780)

## 👷🏼‍♂️ 변경 사항
- 매칭 nodata 상태에서 카드 상단 타이머 앞 텍스트 변경
- MathcinTimer에 prefixMessage 변수 추가
 
## 💬 참고 사항
- 지영님 꼼꼼하십니다!! 짱짱!!!!!!!!

## 📸 스크린샷(Optional)
| AS-IS | TO-BE |
| :--: | :--: |
|![Simulator Screenshot - iPhone 16 Pro - 2025-03-24 at 14 34 50](https://github.com/user-attachments/assets/088b5361-ba3e-450b-8272-58d6cf616be7) | ![image](https://github.com/user-attachments/assets/705b9ad0-6394-49f0-84e0-30d005f577e8) |

[PC-780]: https://yapp25app3.atlassian.net/browse/PC-780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ