### PR TITLE
[PC-748] Fix: Matching main 화면 접근 시, 프로필 리젝 로직 수정

### DIFF
--- a/Data/DTO/Sources/Matches/MatchInfosResponseDTO.swift
+++ b/Data/DTO/Sources/Matches/MatchInfosResponseDTO.swift
@@ -11,7 +11,7 @@ import Entities
 public struct MatchInfosResponseDTO: Decodable {
   public let matchId: Int
   public let matchedUserId: Int
-  public let matchStatus: String
+  public let matchStatus: MatchStatus?
   public let description: String
   public let nickname: String
   public let birthYear: String
@@ -37,3 +37,5 @@ public extension MatchInfosResponseDTO {
     )
   }
 }
+
+extension MatchStatus: Decodable { }

--- a/Domain/Entities/Sources/MatchMain/MatchInfosModel.swift
+++ b/Domain/Entities/Sources/MatchMain/MatchInfosModel.swift
@@ -10,7 +10,7 @@ import SwiftUI
 public struct MatchInfosModel {
   public let matchId: Int
   public let matchedUserId: Int
-  public let matchStatus: String
+  public let matchStatus: MatchStatus?
   public let description: String
   public let nickname: String
   public let birthYear: String
@@ -22,7 +22,7 @@ public struct MatchInfosModel {
   public init(
     matchId: Int,
     matchedUserId: Int,
-    matchStatus: String,
+    matchStatus: MatchStatus?,
     description: String,
     nickname: String,
     birthYear: String,

--- a/Domain/Entities/Sources/MatchMain/MatchStatus.swift
+++ b/Domain/Entities/Sources/MatchMain/MatchStatus.swift
@@ -1,0 +1,16 @@
+//
+//  MatchStatus.swift
+//  Entities
+//
+//  Created by eunseou on 4/5/25.
+//
+
+import SwiftUI
+
+public enum MatchStatus: String {
+  case BEFORE_OPEN
+  case WAITING
+  case RESPONDED
+  case GREEN_LIGHT
+  case MATCHED
+}

--- a/Domain/RepositoryInterfaces/Sources/Settings/SettingsRepositoryInterface.swift
+++ b/Domain/RepositoryInterfaces/Sources/Settings/SettingsRepositoryInterface.swift
@@ -11,7 +11,7 @@ public protocol SettingsRepositoryInterface {
   func getSettingsInfo() async throws -> SettingsInfoModel
   func putSettingsNotification(isEnabled: Bool) async throws -> VoidModel
   func putSettingsMatchNotification(isEnabled: Bool) async throws -> VoidModel
-  func putSettingsBlockAcquaintace(isEnabled: Bool) async throws -> VoidModel
+  func putSettingsBlockAcquaintance(isEnabled: Bool) async throws -> VoidModel
   func getContactsSyncTime() async throws -> ContactsSyncTimeModel
   func patchLogout() async throws -> VoidModel
 }

--- a/Presentation/Feature/MatchingMain/Sources/MatchingAnswer.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingAnswer.swift
@@ -6,77 +6,73 @@
 //
 
 import SwiftUI
+import Entities
 import DesignSystem
 
 public struct MatchingAnswer: View {
-  public enum MatchingStatus {
-    case before
-    case waiting
-    case done
-    case complete
-    case green_light
-    
-    var icon: Image {
-      switch self {
-      case .before, .waiting: DesignSystemAsset.Icons.matchingModeLoading20.swiftUIImage
-      case .done, .complete: DesignSystemAsset.Icons.matchingModeCheck20.swiftUIImage
-      case .green_light: DesignSystemAsset.Icons.matchingModeHeart20.swiftUIImage
-      }
-    }
-    
-    var title: String {
-      switch self {
-      case .before: "오픈 전"
-      case .waiting: "응답 대기중"
-      case .done: "응답 완료"
-      case .complete: "매칭 완료"
-      case .green_light: "그린라이트"
-      }
-    }
-    
-    var titleTextColor: Color {
-      switch self {
-      case .before, .waiting: .grayscaleDark2
-      case .done, .complete, .green_light: .primaryDefault
-      }
-    }
-    
-    var description: String {
-      switch self {
-      case .before: "매칭 조각을 확인해주세요!"
-      case .waiting: "매칭에 응답해주세요!"
-      case .done: "상대방의 응답을 기다려봐요!"
-      case .complete: "상대방과 연결되었어요!"
-      case .green_light: "상대방이 매칭을 수락했어요!"
-      }
-    }
-  }
-  
-  public init(type: MatchingStatus) {
+  public init(type: MatchStatus) {
     self.type = type
   }
   
+  private let type: MatchStatus
+  
   public var body: some View {
     HStack(spacing: 8) {
-      type.icon
-      Text(type.title)
+      icon(for: type)
+      Text(title(for: type))
         .pretendard(.body_S_SB)
-        .foregroundColor(type.titleTextColor)
-      Text(type.description)
+        .foregroundColor(titleTextColor(for: type))
+      Text(description(for: type))
         .pretendard(.body_S_M)
         .foregroundColor(.grayscaleDark3)
     }
   }
   
-  private let type: MatchingStatus
+  private func icon(for status: MatchStatus) -> Image {
+    switch status {
+    case .BEFORE_OPEN, .WAITING:
+      return DesignSystemAsset.Icons.matchingModeLoading20.swiftUIImage
+    case .MATCHED, .RESPONDED:
+      return DesignSystemAsset.Icons.matchingModeCheck20.swiftUIImage
+    case .GREEN_LIGHT:
+      return DesignSystemAsset.Icons.matchingModeHeart20.swiftUIImage
+    }
+  }
+  
+  private func title(for status: MatchStatus) -> String {
+    switch status {
+    case .BEFORE_OPEN: "오픈 전"
+    case .WAITING: "응답 대기중"
+    case .RESPONDED: "응답 완료"
+    case .MATCHED: "매칭 완료"
+    case .GREEN_LIGHT: "그린라이트"
+    }
+  }
+  
+  private func titleTextColor(for status: MatchStatus) -> Color {
+    switch status {
+    case .BEFORE_OPEN, .WAITING: .grayscaleDark2
+    case .RESPONDED, .MATCHED, .GREEN_LIGHT: .primaryDefault
+    }
+  }
+  
+  private func description(for status: MatchStatus) -> String {
+    switch status {
+    case .BEFORE_OPEN: "매칭 조각을 확인해주세요!"
+    case .WAITING: "매칭에 응답해주세요!"
+    case .RESPONDED: "상대방의 응답을 기다려봐요!"
+    case .MATCHED: "상대방과 연결되었어요!"
+    case .GREEN_LIGHT: "상대방이 매칭을 수락했어요!"
+    }
+  }
 }
 
 #Preview {
   VStack {
-    MatchingAnswer(type: .before)
-    MatchingAnswer(type: .waiting)
-    MatchingAnswer(type: .done)
-    MatchingAnswer(type: .complete)
-    MatchingAnswer(type: .green_light)
+    MatchingAnswer(type: .BEFORE_OPEN)
+    MatchingAnswer(type: .WAITING)
+    MatchingAnswer(type: .RESPONDED)
+    MatchingAnswer(type: .MATCHED)
+    MatchingAnswer(type: .GREEN_LIGHT)
   }
 }

--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
@@ -107,7 +107,7 @@ final class MatchingMainViewModel {
   }
   var destination: Route?
   var matchingButtonState: MatchingButtonState = .acceptMatching
-  var matchingStatus: MatchingAnswer.MatchingStatus = .before
+  var matchingStatus: MatchStatus = .BEFORE_OPEN
   
   init(
     getUserInfoUseCase: GetUserInfoUseCase,


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-748](https://yapp25app3.atlassian.net/browse/PC-748)

## 👷🏼‍♂️ 변경 사항
- AS-IS: 화면에 접근할 때마다, 조건 없이 유저의 리젝 사유를 받는 api를 호출
- TO-BE: userinfo를 내려주는 api에서 profileStatus를 가져온다. profileStatus가 REJECTED일 경우에만 api 호출
- MatchStatus enum을 통해 여러 곳에서 중복되어 사용되는 상태값(매칭 전, 대기중 ,수락, 매칭완료, 그린라이트) 통일
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-748]: https://yapp25app3.atlassian.net/browse/PC-748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ