### PR TITLE
[PC-800] Fix: 매칭 수락 후, 매칭 메인(홈) 진입 시 갱신 안되는 현상 수정

### DIFF
--- a/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
+++ b/Presentation/Feature/MatchingMain/Sources/MatchingMainViewModel.swift
@@ -125,6 +125,7 @@ final class MatchingMainViewModel {
     
     Task {
       await getUserRole()
+      await getMatchesInfo()
     }
   }
   
@@ -229,7 +230,7 @@ final class MatchingMainViewModel {
       case .MATCHED:
           // 둘다 수락
         matchingStatus = .MATCHED
-          matchingButtonState = .checkContact(nickname: "")
+        matchingButtonState = .checkContact(nickname: "")
       case nil:
         break
       }


### PR DESCRIPTION
## 🏷️ 티켓 번호
[PC-800](https://yapp25app3.atlassian.net/browse/PC-800)

## 👷🏼‍♂️ 변경 사항
- 매칭 메인 진입 시마다 match info API 호출하도록 변경
 
## 💬 참고 사항
- 이 PR을 보는 사람이 참고해야 할 내용

## 📸 스크린샷(Optional)
| 화면 이름 |
| :--: |
|  |

[PC-800]: https://yapp25app3.atlassian.net/browse/PC-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ